### PR TITLE
NVFP4 Emulation

### DIFF
--- a/run_fp4.py
+++ b/run_fp4.py
@@ -1,4 +1,6 @@
-# SPDX-License-Identifier: Apache-2.0
+
+import numpy
+import torch
 
 from vllm import LLM, SamplingParams
 
@@ -8,17 +10,14 @@ prompts = [
 ]
 
 # Create a sampling params object for greedy sampling
-sampling_params = SamplingParams(temperature=0.90,
-                                 max_tokens=40,
-                                 min_tokens=10)
-#llm = LLM('/home/dsikka/llm-compressor/examples/quantization_w4a16_fp4/TinyLlama-1.1B-Chat-v1.0-FP4', enforce_eager=True)
-llm = LLM(
-    "/home/dsikka/llm-compressor/examples/quantization_w4a16_fp4/Llama-3.1-8B-Instruct-FP4",
-    enforce_eager=True)
-
-#llm = LLM("nvidia/Llama-3.3-70B-Instruct-FP4", quantization='nvfp4', max_model_len=2048, enforce_eager=True)
-#llm = LLM("nm-testing/llama2.c-stories110M-FP4", enforce_eager=True)
+sampling_params = SamplingParams(temperature=0.80, top_p=0.95, max_tokens=40, min_tokens=10)
+#llm  = LLM('nm-testing/Llama-3.1-8B-Instruct-FP4-Weight')
+#llm = LLM("/home/dsikka/llm-compressor/examples/quantization_w4a16_fp4/TinyLlama-1.1B-Chat-v1.0-FP4")
+#llm = LLM("/home/dsikka/llm-compressor/examples/quantization_w4a16_fp4/Llama-3.1-8B-Instruct-NVFP4A16")
+#llm = LLM("/home/dsikka/llm-compressor/examples/quantization_w4a16_fp4/Llama-3.1-8B-Instruct-NVFP4A16-MSE")
+#llm = LLM("nm-testing/Llama-3.3-70B-Instruct-NVFP4A16", max_model_len=4096)
 # Print the outputs.
+llm = LLM("nvidia/Llama-3.3-70B-Instruct-FP4", max_model_len=4096, quantization="nvfp4", enforce_eager=True)
 output = llm.generate(prompts, sampling_params)
 for o in output:
     print(o.outputs[0].text)

--- a/run_fp4.py
+++ b/run_fp4.py
@@ -3,13 +3,14 @@
 from vllm import LLM, SamplingParams
 
 prompts = [
-    "The Swiss Alps are",
-    "The president of the USA is",
+    "The Swiss Alps are", "The president of the USA is",
     "The Boston Bruins are"
 ]
 
 # Create a sampling params object for greedy sampling
-sampling_params = SamplingParams(temperature=0.90, max_tokens=40, min_tokens=10)
+sampling_params = SamplingParams(temperature=0.90,
+                                 max_tokens=40,
+                                 min_tokens=10)
 #llm = LLM('/home/dsikka/llm-compressor/examples/quantization_w4a16_fp4/TinyLlama-1.1B-Chat-v1.0-FP4', enforce_eager=True)
 llm = LLM(
     "/home/dsikka/llm-compressor/examples/quantization_w4a16_fp4/Llama-3.1-8B-Instruct-FP4",

--- a/run_fp4.py
+++ b/run_fp4.py
@@ -1,0 +1,18 @@
+import numpy
+import torch
+
+from vllm import LLM, SamplingParams
+
+prompts = ["The Swiss Alps are", "The president of the USA is", "The Boston Bruins are"]
+
+# Create a sampling params object for greedy sampling
+sampling_params = SamplingParams(temperature=0.80, top_p=0.95, max_tokens=40, min_tokens=10)
+llm  = LLM('nm-testing/llama2.c-stories110M-FP4', enforce_eager=True)
+
+
+# Print the outputs.
+output = llm.generate(prompts, sampling_params)
+for o in output:
+    print(o.outputs[0].text)
+    print("\n")
+    

--- a/run_fp4.py
+++ b/run_fp4.py
@@ -6,10 +6,12 @@ from vllm import LLM, SamplingParams
 prompts = ["The Swiss Alps are", "The president of the USA is", "The Boston Bruins are"]
 
 # Create a sampling params object for greedy sampling
-sampling_params = SamplingParams(temperature=0.80, top_p=0.95, max_tokens=40, min_tokens=10)
-llm  = LLM('nm-testing/llama2.c-stories110M-FP4', enforce_eager=True)
+sampling_params = SamplingParams(max_tokens=40, min_tokens=10)
+#llm = LLM('nm-testing/TinyLlama-1.1B-Chat-v1.0-FP4', enforce_eager=True)
+llm = LLM("/home/dsikka/llm-compressor/examples/quantization_w4a16_fp4/Llama-3.1-8B-Instruct-FP4", enforce_eager=True)
+#llm = LLM("nvidia/Llama-3.3-70B-Instruct-FP4", quantization='nvfp4', max_model_len=2048, enforce_eager=True)
 
-
+#llm = LLM("nm-testing/llama2.c-stories110M-FP4", enforce_eager=True)
 # Print the outputs.
 output = llm.generate(prompts, sampling_params)
 for o in output:

--- a/run_fp4.py
+++ b/run_fp4.py
@@ -1,20 +1,24 @@
-import numpy
-import torch
+# SPDX-License-Identifier: Apache-2.0
 
 from vllm import LLM, SamplingParams
 
-prompts = ["The Swiss Alps are", "The president of the USA is", "The Boston Bruins are"]
+prompts = [
+    "The Swiss Alps are",
+    "The president of the USA is",
+    "The Boston Bruins are"
+]
 
 # Create a sampling params object for greedy sampling
-sampling_params = SamplingParams(max_tokens=40, min_tokens=10)
-#llm = LLM('nm-testing/TinyLlama-1.1B-Chat-v1.0-FP4', enforce_eager=True)
-llm = LLM("/home/dsikka/llm-compressor/examples/quantization_w4a16_fp4/Llama-3.1-8B-Instruct-FP4", enforce_eager=True)
-#llm = LLM("nvidia/Llama-3.3-70B-Instruct-FP4", quantization='nvfp4', max_model_len=2048, enforce_eager=True)
+sampling_params = SamplingParams(temperature=0.90, max_tokens=40, min_tokens=10)
+#llm = LLM('/home/dsikka/llm-compressor/examples/quantization_w4a16_fp4/TinyLlama-1.1B-Chat-v1.0-FP4', enforce_eager=True)
+llm = LLM(
+    "/home/dsikka/llm-compressor/examples/quantization_w4a16_fp4/Llama-3.1-8B-Instruct-FP4",
+    enforce_eager=True)
 
+#llm = LLM("nvidia/Llama-3.3-70B-Instruct-FP4", quantization='nvfp4', max_model_len=2048, enforce_eager=True)
 #llm = LLM("nm-testing/llama2.c-stories110M-FP4", enforce_eager=True)
 # Print the outputs.
 output = llm.generate(prompts, sampling_params)
 for o in output:
     print(o.outputs[0].text)
     print("\n")
-    

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -303,7 +303,7 @@ class CompressedTensorsConfig(QuantizationConfig):
         is_group_quant = weight_quant.strategy == QuantizationStrategy.GROUP.value
         is_group_size_16 = weight_quant.group_size == 16
         is_float_type = weight_quant.type == QuantizationType.FLOAT
-        is_4_bits = weight_quant.num_bits == 8
+        is_4_bits = weight_quant.num_bits == 4
         return is_group_quant and is_float_type and is_4_bits
 
     def _is_wNa16_group_channel(self, weight_quant: BaseModel,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/__init__.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/__init__.py
@@ -8,6 +8,7 @@ from .compressed_tensors_w8a8_int8 import CompressedTensorsW8A8Int8
 from .compressed_tensors_w8a16_fp8 import CompressedTensorsW8A16Fp8
 from .compressed_tensors_wNa16 import (WNA16_SUPPORTED_BITS,
                                        CompressedTensorsWNA16)
+from .compressed_tensors_w4a4_nvfp4 import CompressedTensorsW4A4Fp4
 
 from .compressed_tensors_24 import CompressedTensors24  # isort: skip
 

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/__init__.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/__init__.py
@@ -16,5 +16,5 @@ __all__ = [
     "CompressedTensorsW8A16Fp8", "CompressedTensorsW4A16Sparse24",
     "CompressedTensorsW8A8Int8", "CompressedTensorsW8A8Fp8",
     "WNA16_SUPPORTED_BITS", "W4A16SPARSE24_SUPPORTED_BITS",
-    "CompressedTensors24"
+    "CompressedTensors24", "CompressedTensorsW4A4Fp4"
 ]

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -9,7 +9,7 @@ from torch.nn.parameter import Parameter
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsScheme)
 from vllm.model_executor.layers.quantization.utils.nvfp4_emulation_utils import (
-    dequantize_to_dtype, expand_global_scale)
+    dequantize_to_dtype)
 from vllm.model_executor.parameter import (GroupQuantScaleParameter,
                                            ModelWeightParameter,
                                            PerTensorScaleParameter)
@@ -90,7 +90,9 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
 
     def process_weights_after_loading(self, layer) -> None:
         print(layer.weight_global_scale)
-        layer.weight_global_scale = Parameter(layer.weight_global_scale.max().to(torch.float32), requires_grad=False)
+        layer.weight_global_scale = Parameter(
+            layer.weight_global_scale.max().to(torch.float32),
+            requires_grad=False)
         # Note: a post weight loading step but not required for the emulation
         swizzled_weight_scale = self.swizzle_blockscale(layer.weight_scale)
         layer.weight_scale_swizzled = Parameter(swizzled_weight_scale,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -37,8 +37,8 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
         weight = ModelWeightParameter(
             data=torch.empty(
                 # 2 fp4 items are packed in the input dimension
-                layer.output_size_per_partition,
-                layer.input_size_per_partition // 2,
+                sum(output_partition_sizes),
+                input_size_per_partition // 2,
                 dtype=torch.uint8),
             input_dim=1,
             output_dim=0,
@@ -53,7 +53,7 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
 
         # Per Group Weight Scale
         weight_scale = GroupQuantScaleParameter(data=torch.empty(
-            output_size_per_partition,
+            sum(output_partition_sizes),
             input_size_per_partition // self.group_size,
             dtype=torch.float8_e4m3fn,
         ),

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Callable, List, Optional
+
+import torch
+
+from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
+    CompressedTensorsScheme)
+from torch.nn.parameter import Parameter
+from vllm.model_executor.parameter import (ModelWeightParameter,
+                                           PerTensorScaleParamete, GroupQuantScaleParameter)
+from vllm.platforms import current_platform
+from vllm.model_executor.layers.quantization.utils.nvfp4_emulation_utils import (
+    dequantize_to_dtype
+)
+
+__all__ = ["CompressedTensorsW4A4Fp4"]
+
+
+class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
+    def __init__(self):
+        self.group_size = 16 
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        # dont restrict as emulations
+        return 80
+
+    def process_weights_after_loading(self, layer) -> None:
+        weight_global_scale = layer.weight_global_scale.max().to(torch.float32)
+        layer.weight_global_scale = Parameter(weight_global_scale, requires_grad=False)
+
+    def create_weights(self, layer: torch.nn.Module,
+                       output_partition_sizes: List[int],
+                       input_size_per_partition: int,
+                       params_dtype: torch.dtype, weight_loader: Callable,
+                       **kwargs):
+        
+        # Weight
+        weight = ModelWeightParameter(
+            data=torch.empty(
+                # 2 fp4 items are packed in the input dimension
+                layer.output_size_per_partition,
+                layer.input_size_per_partition // 2,
+                dtype=torch.uint8),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader)
+        layer.register_parameter("weight_packed", weight)
+
+        # Input Scale
+        input_scale = PerTensorScaleParameter(data=torch.empty(
+            len(output_partition_sizes), dtype=torch.float32),
+                                              weight_loader=weight_loader)
+        layer.register_parameter("input_scale", input_scale)
+
+        # Global Weight Scale
+        weight_global_scale = PerTensorScaleParameter(data=torch.empty(
+            len(output_partition_sizes), dtype=torch.float32),
+                                                 weight_loader=weight_loader)
+        layer.register_parameter("weight_global_scale", weight_global_scale)
+
+        # Per Group Weight Scale
+        weight_scale = GroupQuantScaleParameter(data=torch.empty(
+            output_size_per_partition,
+            input_size_per_partition // group_size,
+            dtype=weight_dtype,
+        ),
+                                            input_dim=1,
+                                            output_dim=0,
+                                            weight_loader=weight_loader)
+
+        layer.register_parameter("weight_scale", weight_scale)
+
+    def apply_weights(self,
+                      layer: torch.nn.Module,
+                      x: torch.Tensor,
+                      bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+
+
+        w_fp4 = layer.weight_packed.data
+        w_blockscale = layer.weight_scale
+        w_global_scale = layer.weight_global_scale
+        w_dq = dequantize_to_dtype(w_fp4, w_blockscale, w_global_scale,
+                                   x.dtype, x.device, self.group_size)
+
+        return F.linear(x, w_dq)
+

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -20,108 +20,13 @@ from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
 from vllm.model_executor.parameter import (ModelWeightParameter,
                                            PerTensorScaleParameter)
 from vllm.platforms import current_platform
-from vllm.scalar_type import scalar_types
+from vllm.model_executor.layers.quantization.utils.nvfp4_emulation_utils import (
+    ref_nvfp4_quant, dequantize_to_dtype)
 
 logger = init_logger(__name__)
 
 QUANT_ALGOS = ["FP8", "NVFP4"]
 KV_CACHE_QUANT_ALGOS = ["FP8"]
-
-FLOAT4_E2M1_MAX = scalar_types.float4_e2m1fn.max()
-
-kE2M1ToFloat = torch.tensor([0., 0.5, 1., 1.5, 2., 3., 4., 6.],
-                            dtype=torch.float32)
-
-
-def break_fp4_bytes(a, dtype):
-    assert a.dtype == torch.uint8
-    m, n = a.shape
-    # Vectorized nibble processing
-    a_flat = a.flatten()
-    high = (a_flat & 0xF0) >> 4  # Upper nibbles
-    low = a_flat & 0x0F  # Lower nibbles
-    # Combine nibbles for batch processing
-    combined = torch.stack((low, high), dim=1).flatten()
-    # Vectorized sign and magnitude extraction
-    signs = (combined & 0x08).to(torch.bool)  # Sign bits
-    abs_vals = (combined & 0x07).to(torch.long)
-    # Device-aware lookup and sign application
-    kE2M1 = kE2M1ToFloat.to(device=a.device)
-    values = kE2M1[abs_vals] * torch.where(signs, -1.0, 1.0)
-    # Reshape to final form
-    return values.reshape(m, n * 2).to(dtype=dtype)
-
-
-def convert_swizzled_to_linear(a_sf_swizzled: torch.Tensor, m, k, block_size):
-    m_tiles = (m + 128 - 1) // 128
-    f = block_size * 4
-    k_tiles = (k + f - 1) // f
-    tmp = torch.reshape(a_sf_swizzled, (1, m_tiles, k_tiles, 32, 4, 4))
-    tmp = torch.permute(tmp, (0, 1, 4, 3, 2, 5))
-    out = tmp.reshape(m_tiles * 128, k_tiles * f // block_size)
-    return out[0:m, 0:k]
-
-
-def dequantize_to_dtype(tensor_fp4,
-                        tensor_sf,
-                        global_scale,
-                        dtype,
-                        device,
-                        block_size=16):
-    """Dequantize the fp4 tensor back to high precision."""
-    # Two fp4 values are packed into one uint8.
-    assert tensor_fp4.dtype == torch.uint8
-    m, packed_k = tensor_fp4.shape
-    k = packed_k * 2
-    tensor_f32 = break_fp4_bytes(tensor_fp4, torch.float32)
-    tensor_f32 = tensor_f32.reshape(m, k // block_size, block_size)
-    tensor_sf = tensor_sf.view(torch.float8_e4m3fn)
-    tensor_sf = convert_swizzled_to_linear(tensor_sf, m, k, block_size)
-    tensor_sf_dtype = tensor_sf.to(torch.float32) * global_scale
-
-    # scale the tensor
-    out = (tensor_f32 * tensor_sf_dtype.unsqueeze(-1)).reshape(m, k)
-    return out.to(dtype)
-
-
-def cast_to_fp4(x):
-    sign = torch.sign(x)
-    x = torch.abs(x)
-    x[(x >= 0.0) & (x <= 0.25)] = 0.0
-    x[(x > 0.25) & (x < 0.75)] = 0.5
-    x[(x >= 0.75) & (x <= 1.25)] = 1.0
-    x[(x > 1.25) & (x < 1.75)] = 1.5
-    x[(x >= 1.75) & (x <= 2.5)] = 2.0
-    x[(x > 2.5) & (x < 3.5)] = 3.0
-    x[(x >= 3.5) & (x <= 5.0)] = 4.0
-    x[x > 5.0] = 6.0
-    return x * sign
-
-
-def get_reciprocal(x):
-    if isinstance(x, torch.Tensor):
-        return torch.where(x == 0, torch.tensor(0.0, dtype=x.dtype), 1.0 / x)
-    elif isinstance(x, (float, int)):
-        return 0.0 if x == 0 else 1.0 / x
-    else:
-        raise TypeError("Input must be a float, int, or a torch.Tensor.")
-
-
-def ref_nvfp4_quant(x, global_scale, block_size):
-    assert global_scale.dtype == torch.float32
-    assert x.ndim == 2
-    m, n = x.shape
-    x = torch.reshape(x, (m, n // block_size, block_size))
-    vec_max = torch.max(torch.abs(x), dim=-1,
-                        keepdim=True)[0].to(torch.float32)
-    scale = global_scale * (vec_max * get_reciprocal(FLOAT4_E2M1_MAX))
-    scale = scale.to(torch.float8_e4m3fn).to(torch.float32)
-    output_scale = get_reciprocal(scale * get_reciprocal(global_scale))
-
-    scaled_x = x.to(torch.float32) * output_scale
-    clipped_x = torch.clamp(scaled_x, -6.0, 6.0).reshape(m, n)
-    # both outputs are float32
-    return cast_to_fp4(clipped_x), scale.squeeze(-1)
 
 
 class ModelOptFp8Config(QuantizationConfig):
@@ -289,7 +194,7 @@ class ModelOptNvFp4Config(QuantizationConfig):
 
     @classmethod
     def get_min_capability(cls) -> int:
-        return 89
+        return 80
 
     @classmethod
     def get_config_filenames(cls) -> List[str]:
@@ -508,7 +413,7 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
         # dequantize weight
         w_fp4 = layer.weight.data.view(torch.uint8)
         w_blockscale = layer.weight_scale_swizzled.data
-        w_global_scale = layer.weight_scale_2
+        w_global_scale = 1 / layer.weight_scale_2
         # print(f"{w_fp4.shape=}")
         # print(f"{w_blockscale.shape=}")
         # print(f"{w_global_scale.shape=}")

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -22,6 +22,9 @@ from vllm.model_executor.parameter import (ModelWeightParameter,
 from vllm.platforms import current_platform
 from vllm.model_executor.layers.quantization.utils.nvfp4_emulation_utils import (
     ref_nvfp4_quant, dequantize_to_dtype)
+from math import ceil
+import torch._dynamo
+torch._dynamo.config.suppress_errors = True
 
 logger = init_logger(__name__)
 
@@ -388,43 +391,27 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
 
         # for input only the contracting dimension has a constraint.
         x_m, x_k = x.shape
-        w_n, w_k = layer.weight.shape
-        # print(f"{x.shape=}")
-        # print(f"{layer.weight.shape=}")
-        output_shape = [x_m, w_n]
-        block_size = 16
-        """
+        block_size = group_size = 16
+       
         # quantize input to (FP4 and interleaved block scale)
-        # x_global_scale = layer.input_scale
         x_global_scale = 1 / layer.input_scale
-        # x_fp4, x_blockscale = scaled_fp4_quant(x, s_quant)
         x_fp4, x_blockscale = ref_nvfp4_quant(x, x_global_scale, block_size)
-        # x_blockscale = self.swizzle_blockscale(x_blockscale)
-        # print(f"{x_fp4.shape=}")
-        # print(f"{x_blockscale.shape=}")
 
         # dequantize input
         x_fp4 = x_fp4.reshape(x_m, x_k // block_size, block_size)
         x_blockscale = x_blockscale.unsqueeze(-1) / x_global_scale
         x_dq = (x_fp4 * x_blockscale).reshape(x_m, x_k).to(output_dtype)
         del x_fp4, x_blockscale
-        """
-
+    
         # dequantize weight
         w_fp4 = layer.weight.data.view(torch.uint8)
         w_blockscale = layer.weight_scale_swizzled.data
         w_global_scale = 1 / layer.weight_scale_2
-        # print(f"{w_fp4.shape=}")
-        # print(f"{w_blockscale.shape=}")
-        # print(f"{w_global_scale.shape=}")
         w_dq = dequantize_to_dtype(w_fp4, w_blockscale, w_global_scale,
                                    output_dtype, x.device, block_size)
 
         # matmul
-        out = torch.matmul(x, w_dq.t())
-        # del x_dq, w_dq
-        # print(f"{out.shape=}")
-
-        if bias is not None:
-            out = out + bias
-        return out.view(*output_shape)
+        out = torch.matmul(x_dq, w_dq.t())
+        del w_dq, x_dq
+        return out
+       

--- a/vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py
@@ -3,10 +3,7 @@ import torch
 
 from vllm.scalar_type import scalar_types
 
-__all__ = [
-    "break_fp4_bytes", "dequantize_to_dtype", "ref_nvfp4_quant",
-    "dequantize_unfused", "requantize_with_max", "expand_global_scale"
-]
+__all__ = ["break_fp4_bytes", "dequantize_to_dtype", "ref_nvfp4_quant"]
 
 FLOAT4_E2M1_MAX = scalar_types.float4_e2m1fn.max()
 
@@ -136,17 +133,3 @@ def ref_nvfp4_quant(x, global_scale, block_size):
     clipped_x = torch.clamp(scaled_x, -6.0, 6.0).reshape(m, n)
     # both outputs are float32
     return cast_to_fp4(clipped_x), scale.squeeze(-1)
-
-
-def expand_global_scale(local_scale, sizes, global_scale):
-    output_scale = torch.zeros(local_scale.shape, dtype=global_scale.dtype).to(
-        global_scale.device)
-    end = 0
-    for i in range(len(sizes)):
-        size = sizes[i]
-        current_global_scale = global_scale[i]
-        start = end
-        end = start + size
-        output_scale[start:end, :] = current_global_scale
-
-    return output_scale

--- a/vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py
@@ -55,8 +55,8 @@ def dequantize_to_dtype(tensor_fp4,
     k = packed_k * 2
     tensor_f32 = break_fp4_bytes(tensor_fp4, torch.float32)
     tensor_f32 = tensor_f32.reshape(m, k // block_size, block_size)
-    tensor_sf = tensor_sf.view(torch.float8_e4m3fn)
-    tensor_sf = convert_swizzled_to_linear(tensor_sf, m, k, block_size)
+    #tensor_sf = tensor_sf.view(torch.float8_e4m3fn)
+    #tensor_sf = convert_swizzled_to_linear(tensor_sf, m, k, block_size)
     tensor_sf_dtype = tensor_sf.to(torch.float32) / global_scale
 
     # scale the tensor

--- a/vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py
@@ -55,8 +55,8 @@ def dequantize_to_dtype(tensor_fp4,
     k = packed_k * 2
     tensor_f32 = break_fp4_bytes(tensor_fp4, torch.float32)
     tensor_f32 = tensor_f32.reshape(m, k // block_size, block_size)
-    #tensor_sf = tensor_sf.view(torch.float8_e4m3fn)
-    #tensor_sf = convert_swizzled_to_linear(tensor_sf, m, k, block_size)
+    tensor_sf = tensor_sf.view(torch.float8_e4m3fn)
+    tensor_sf = convert_swizzled_to_linear(tensor_sf, m, k, block_size)
     tensor_sf_dtype = tensor_sf.to(torch.float32) / global_scale
 
     # scale the tensor

--- a/vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py
@@ -64,6 +64,7 @@ def dequantize_to_dtype(tensor_fp4,
     out = (tensor_f32 * tensor_sf_dtype.unsqueeze(-1)).reshape(m, k)
     return out.to(dtype)
 
+
 def dequantize_unfused(tensor_fp4,
                        tensor_sf,
                        global_scale,

--- a/vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py
@@ -1,0 +1,104 @@
+import torch
+from vllm.scalar_type import scalar_types
+
+__all__ = [
+    "break_fp4_bytes",
+    "dequantize_to_dtype",
+    "ref_nvfp4_quant"
+]
+
+FLOAT4_E2M1_MAX = scalar_types.float4_e2m1fn.max()
+
+kE2M1ToFloat = torch.tensor([0., 0.5, 1., 1.5, 2., 3., 4., 6.],
+                            dtype=torch.float32)
+
+
+def break_fp4_bytes(a, dtype):
+    assert a.dtype == torch.uint8
+    m, n = a.shape
+    # Vectorized nibble processing
+    a_flat = a.flatten()
+    high = (a_flat & 0xF0) >> 4  # Upper nibbles
+    low = a_flat & 0x0F  # Lower nibbles
+    # Combine nibbles for batch processing
+    combined = torch.stack((low, high), dim=1).flatten()
+    # Vectorized sign and magnitude extraction
+    signs = (combined & 0x08).to(torch.bool)  # Sign bits
+    abs_vals = (combined & 0x07).to(torch.long)
+    # Device-aware lookup and sign application
+    kE2M1 = kE2M1ToFloat.to(device=a.device)
+    values = kE2M1[abs_vals] * torch.where(signs, -1.0, 1.0)
+    # Reshape to final form
+    return values.reshape(m, n * 2).to(dtype=dtype)
+
+
+def convert_swizzled_to_linear(a_sf_swizzled: torch.Tensor, m, k, block_size):
+    m_tiles = (m + 128 - 1) // 128
+    f = block_size * 4
+    k_tiles = (k + f - 1) // f
+    tmp = torch.reshape(a_sf_swizzled, (1, m_tiles, k_tiles, 32, 4, 4))
+    tmp = torch.permute(tmp, (0, 1, 4, 3, 2, 5))
+    out = tmp.reshape(m_tiles * 128, k_tiles * f // block_size)
+    return out[0:m, 0:k]
+
+
+def dequantize_to_dtype(tensor_fp4,
+                        tensor_sf,
+                        global_scale,
+                        dtype,
+                        device,
+                        block_size=16):
+    """Dequantize the fp4 tensor back to high precision."""
+    # Two fp4 values are packed into one uint8.
+    assert tensor_fp4.dtype == torch.uint8
+    m, packed_k = tensor_fp4.shape
+    k = packed_k * 2
+    tensor_f32 = break_fp4_bytes(tensor_fp4, torch.float32)
+    tensor_f32 = tensor_f32.reshape(m, k // block_size, block_size)
+    tensor_sf = tensor_sf.view(torch.float8_e4m3fn)
+    tensor_sf = convert_swizzled_to_linear(tensor_sf, m, k, block_size)
+    tensor_sf_dtype = tensor_sf.to(torch.float32) / global_scale
+
+    # scale the tensor
+    out = (tensor_f32 * tensor_sf_dtype.unsqueeze(-1)).reshape(m, k)
+    return out.to(dtype)
+
+
+def cast_to_fp4(x):
+    sign = torch.sign(x)
+    x = torch.abs(x)
+    x[(x >= 0.0) & (x <= 0.25)] = 0.0
+    x[(x > 0.25) & (x < 0.75)] = 0.5
+    x[(x >= 0.75) & (x <= 1.25)] = 1.0
+    x[(x > 1.25) & (x < 1.75)] = 1.5
+    x[(x >= 1.75) & (x <= 2.5)] = 2.0
+    x[(x > 2.5) & (x < 3.5)] = 3.0
+    x[(x >= 3.5) & (x <= 5.0)] = 4.0
+    x[x > 5.0] = 6.0
+    return x * sign
+
+
+def get_reciprocal(x):
+    if isinstance(x, torch.Tensor):
+        return torch.where(x == 0, torch.tensor(0.0, dtype=x.dtype), 1.0 / x)
+    elif isinstance(x, (float, int)):
+        return 0.0 if x == 0 else 1.0 / x
+    else:
+        raise TypeError("Input must be a float, int, or a torch.Tensor.")
+
+
+def ref_nvfp4_quant(x, global_scale, block_size):
+    assert global_scale.dtype == torch.float32
+    assert x.ndim == 2
+    m, n = x.shape
+    x = torch.reshape(x, (m, n // block_size, block_size))
+    vec_max = torch.max(torch.abs(x), dim=-1,
+                        keepdim=True)[0].to(torch.float32)
+    scale = global_scale * (vec_max * get_reciprocal(FLOAT4_E2M1_MAX))
+    scale = scale.to(torch.float8_e4m3fn).to(torch.float32)
+    output_scale = get_reciprocal(scale * get_reciprocal(global_scale))
+
+    scaled_x = x.to(torch.float32) * output_scale
+    clipped_x = torch.clamp(scaled_x, -6.0, 6.0).reshape(m, n)
+    # both outputs are float32
+    return cast_to_fp4(clipped_x), scale.squeeze(-1)

--- a/vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py
@@ -128,6 +128,7 @@ def ref_nvfp4_quant(x, global_scale, block_size):
     vec_max = torch.max(torch.abs(x), dim=-1,
                         keepdim=True)[0].to(torch.float32)
     scale = global_scale * (vec_max * get_reciprocal(FLOAT4_E2M1_MAX))
+    scale = torch.clamp(scale, max=448, min=-448)
     scale = scale.to(torch.float8_e4m3fn).to(torch.float32)
     output_scale = get_reciprocal(scale * get_reciprocal(global_scale))
 

--- a/vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py
@@ -1,13 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
 import torch
+
 from vllm.scalar_type import scalar_types
 
 __all__ = [
-    "break_fp4_bytes",
-    "dequantize_to_dtype",
-    "ref_nvfp4_quant",
-    "dequantize_unfused",
-    "requantize_with_max",
-    "expand_global_scale"
+    "break_fp4_bytes", "dequantize_to_dtype", "ref_nvfp4_quant",
+    "dequantize_unfused", "requantize_with_max", "expand_global_scale"
 ]
 
 FLOAT4_E2M1_MAX = scalar_types.float4_e2m1fn.max()
@@ -56,10 +54,8 @@ def dequantize_to_dtype(tensor_fp4,
     assert tensor_fp4.dtype == torch.uint8
     m, packed_k = tensor_fp4.shape
     k = packed_k * 2
-    #m, k = tensor_fp4.shape
     tensor_f32 = break_fp4_bytes(tensor_fp4, torch.float32)
     tensor_f32 = tensor_f32.reshape(m, k // block_size, block_size)
-    #tensor_f32 = tensor_fp4.reshape(m, k // block_size, block_size)
     tensor_sf = tensor_sf.view(torch.float8_e4m3fn)
     tensor_sf = convert_swizzled_to_linear(tensor_sf, m, k, block_size)
     tensor_sf_dtype = tensor_sf.to(torch.float32) / global_scale
@@ -68,13 +64,12 @@ def dequantize_to_dtype(tensor_fp4,
     out = (tensor_f32 * tensor_sf_dtype.unsqueeze(-1)).reshape(m, k)
     return out.to(dtype)
 
-
 def dequantize_unfused(tensor_fp4,
-                        tensor_sf,
-                        global_scale,
-                        dtype,
-                        device,
-                        block_size=16):
+                       tensor_sf,
+                       global_scale,
+                       dtype,
+                       device,
+                       block_size=16):
 
     assert tensor_fp4.dtype == torch.uint8
     m, packed_k = tensor_fp4.shape
@@ -142,15 +137,14 @@ def ref_nvfp4_quant(x, global_scale, block_size):
 
 
 def expand_global_scale(local_scale, sizes, global_scale):
-    output_scale = torch.zeros(local_scale.shape, dtype=global_scale.dtype).to(global_scale.device)
+    output_scale = torch.zeros(local_scale.shape, dtype=global_scale.dtype).to(
+        global_scale.device)
     end = 0
     for i in range(len(sizes)):
         size = sizes[i]
         current_global_scale = global_scale[i]
-        start = end 
+        start = end
         end = start + size
         output_scale[start:end, :] = current_global_scale
 
-    print(output_scale)
-    print(global_scale)
     return output_scale


### PR DESCRIPTION
Summary:

- Add CompressedTensors NVFP4 Emulation Scheme
- Move emulations functionality into shared utilities

ModelOpt Emulation Changes:
- Don't run activations quantization to start --> seemed to be getting gibberish even with it turned off
- Update how the global scale is applied. I think they're storing the inverse? Updating this allows the coherent outputs for the Nvidia 70b checkpoint


Should now support ct models produced and compressed from the following branches:
1. FP4 Weights: https://github.com/neuralmagic/compressed-tensors/pull/287 
2. Compression: https://github.com/neuralmagic/compressed-tensors/pull/291
3. LLM Compressor: https://github.com/vllm-project/llm-compressor/pull/1309

lm-evals/generations should work with weight only dequant:

```bash
lm_eval --model vllm \
    --model_args pretrained=nm-testing/llama2.c-stories110M-FP4,enforce_eager=True \
    --tasks gsm8k \
    --device cuda:0 \
    --batch_size 8
```


```python

import numpy
import torch

from vllm import LLM, SamplingParams

prompts = ["The Swiss Alps are", "The president of the USA is", "The Boston Bruins are"]

# Create a sampling params object for greedy sampling
sampling_params = SamplingParams(temperature=0.80, top_p=0.95, max_tokens=40, min_tokens=10)
llm  = LLM('nm-testing/llama2.c-stories110M-FP4', enforce_eager=True)


# Print the outputs.
output = llm.generate(prompts, sampling_params)
for o in output:
    print(o.outputs[0].text)
    print("\n")
```

ToDo: 
- Generally activation quant support - still need to understand how the input scales should be applied
- Improve compression speed in compressed-tensors. The current speed is a bottleneck atm