### PR TITLE
[Bugfix][P/D] Fix Preemption + Prefix Cache Bug

### DIFF
--- a/tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py
+++ b/tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py
@@ -107,9 +107,7 @@ def test_basic_lifecycle():
 
     # Step (4): Hit EOS.
     scheduler_output = scheduler.schedule()
-    # model_runner_output = create_model_runner_output([request], use_eos=True)
-    breakpoint()
-    model_runner_output = create_model_runner_output([request], use_eos=False)
+    model_runner_output = create_model_runner_output([request], use_eos=True)
     engine_core_outputs = scheduler.update_from_output(scheduler_output,
                                                        model_runner_output)
     scheduler.schedule()

--- a/tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py
+++ b/tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py
@@ -107,7 +107,9 @@ def test_basic_lifecycle():
 
     # Step (4): Hit EOS.
     scheduler_output = scheduler.schedule()
-    model_runner_output = create_model_runner_output([request], use_eos=True)
+    # model_runner_output = create_model_runner_output([request], use_eos=True)
+    breakpoint()
+    model_runner_output = create_model_runner_output([request], use_eos=False)
     engine_core_outputs = scheduler.update_from_output(scheduler_output,
                                                        model_runner_output)
     scheduler.schedule()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -690,7 +690,8 @@ class NixlConnectorWorker:
         # just notify P worker that we have the blocks we need.
         num_local_blocks = len(local_block_ids)
         if num_local_blocks == 0:
-            self.nixl_wrapper.send_notif(dst_engine_id,
+            agent_name = self._remote_agents[dst_engine_id]
+            self.nixl_wrapper.send_notif(agent_name,
                                          notif_msg=request_id.encode("utf-8"))
             return
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -411,6 +411,13 @@ class Scheduler(SchedulerInterface):
                     delay_cache_blocks=load_kv_async,
                 )
                 if new_blocks is None:
+                    # P/D: if the request is recved on this step,
+                    # then we need to free the kv cache blocks
+                    if num_prealloc_computed_tokens > 0:
+                        assert request.num_computed_tokens != 0
+                        self.kv_cache_manager.free(request)
+                        request.num_computed_tokens = 0
+
                     # The request cannot be scheduled.
                     break
 


### PR DESCRIPTION
SUMMARY:
* fix issue related to request preemption. The error occurred in a subtle case. When a request is recved, if there are no blocks to schedule, we did not free the blocks. As a result, when the request is scheduled from waiting an invariant is broken (i.e. that a preempted resumed request has no blocks). The solution is to just free the blocks if the request cannot be scheduled
* fix issue related to prefix cache hit. If we had a 100% prefix cache hit the server would crash due to sending the notify to the engine id instead of agent time. The solution is to just pass the agent name

TODO (follow up):
* upstream
* ci/cd