### PR TITLE
[Bugfix][Speculative Decoding] Fix Eagle3 quantization config inheritance

### DIFF
--- a/tests/speculative_decoding/speculators/test_eagle3.py
+++ b/tests/speculative_decoding/speculators/test_eagle3.py
@@ -14,6 +14,9 @@ from vllm.model_executor.models.interfaces import supports_eagle3
     pytest.param(
         "nm-testing/Speculator-Qwen3-8B-Eagle3-converted-071-quantized",
         id="qwen3-eagle3-speculator"),
+    pytest.param(
+        "nm-testing/Speculator-Qwen3-8B-Eagle3-converted-071-quantized-w4a16",
+        id="qwen3-eagle3-speculator-w4a16-verifier"),
 ])
 def test_eagle3_speculators_model(vllm_runner, example_prompts, model_path,
                                   monkeypatch):

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -248,7 +248,7 @@ class LlamaDecoderLayer(nn.Module):
 
         config = config or vllm_config.model_config.hf_config
         cache_config = vllm_config.cache_config
-        quant_config = vllm_config.quant_config
+        quant_config = self.get_quant_config(vllm_config)
 
         self.hidden_size = config.hidden_size
         rope_theta = getattr(config, "rope_theta", 10000)
@@ -327,6 +327,11 @@ class LlamaDecoderLayer(nn.Module):
             hidden_states, residual)
         hidden_states = self.mlp(hidden_states)
         return hidden_states, residual
+
+    def get_quant_config(
+            self, vllm_config: VllmConfig) -> Optional[QuantizationConfig]:
+        """Get quantization config for this layer. Override in subclasses."""
+        return vllm_config.quant_config
 
 
 @support_torch_compile


### PR DESCRIPTION
Eagle3 drafters were incorrectly inheriting the verifier's quantization
configuration instead of using their own, causing KeyError when loading
unquantized drafter weights with quantized verifiers.

This implements a clean inheritance pattern where:
- Base LlamaDecoderLayer has configurable get_quant_config() method
- Eagle3 LlamaDecoderLayer overrides to use drafter's quantization config
- Uses existing VllmConfig.get_quantization_config() infrastructure
