### PR TITLE
revert max split heuristics

### DIFF
--- a/csrc/attention/mla/cutlass_sm100_mla/device/sm100_mla.hpp
+++ b/csrc/attention/mla/cutlass_sm100_mla/device/sm100_mla.hpp
@@ -134,13 +134,6 @@ public:
     int max_splits = ceil_div(K, 128);
     max_splits = min(16, max_splits);
 
-    // TODO: This avoids a hang when the batch size larger than 1 and 
-    // there is more than 1 kv_splits. 
-    // Discuss with NVIDIA how this can be fixed.
-    if (B > 1) {
-      max_splits = min(1, max_splits);
-    }
-    
     // printf("    max_splits = %d\n", max_splits);
     int sms_per_batch = max(1, sm_count / B);
     // printf("    sms_per_batch = %d\n", sms_per_batch);


### PR DESCRIPTION
Try reverting: https://github.com/vllm-project/vllm/pull/25509 https://github.com/vllm-project/vllm/pull/24966 now that we have  https://github.com/vllm-project/vllm/pull/26026