### PR TITLE
feat: Support Hybrid Attention Models with `extract_hidden_states`

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -27,7 +27,9 @@ from vllm.v1.core.kv_cache_utils import (
     estimate_max_model_len,
     generate_block_hash_extra_keys,
     generate_scheduler_kv_cache_config,
+    get_kv_cache_config_from_groups,
     get_kv_cache_configs,
+    get_kv_cache_groups,
     get_max_concurrency_for_kv_cache_config,
     get_request_block_hasher,
     hash_block_tokens,
@@ -37,6 +39,7 @@ from vllm.v1.core.kv_cache_utils import (
     tensor_data,
 )
 from vllm.v1.kv_cache_interface import (
+    CacheOnlySpec,
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
     KVCacheConfig,
@@ -2137,3 +2140,114 @@ def test_unify_hybrid_kv_cache_specs():
 
     with pytest.raises(ValueError):
         kv_cache_utils.unify_hybrid_kv_cache_specs(kv_cache_spec)
+
+
+def new_cache_only_spec(
+    block_size=16,
+    num_hidden_states=3,
+    hidden_size=64,
+    dtype=torch.float32,
+):
+    return CacheOnlySpec(
+        block_size=block_size,
+        num_hidden_states=num_hidden_states,
+        hidden_size=hidden_size,
+        dtype=dtype,
+    )
+
+
+def test_cache_only_spec_page_size():
+    spec = new_cache_only_spec(
+        block_size=16, num_hidden_states=3, hidden_size=64, dtype=torch.float32
+    )
+    # float32 = 4 bytes; page = 16 * 3 * 64 * 4
+    assert spec.page_size_bytes == 16 * 3 * 64 * 4
+
+    spec_bf16 = new_cache_only_spec(
+        block_size=8, num_hidden_states=2, hidden_size=128, dtype=torch.bfloat16
+    )
+    # bfloat16 = 2 bytes; page = 8 * 2 * 128 * 2
+    assert spec_bf16.page_size_bytes == 8 * 2 * 128 * 2
+
+
+def test_get_kv_cache_groups_cache_only_pure_attention():
+    """CacheOnly pre-extracted before routing; appended as last group."""
+    vllm_config = VllmConfig(model_config=ModelConfig(max_model_len=16))
+    kv_cache_spec = {
+        "layer_1": new_kv_cache_spec(),
+        "layer_2": new_kv_cache_spec(),
+        "cache_only_0": new_cache_only_spec(),
+    }
+    groups = get_kv_cache_groups(vllm_config, kv_cache_spec)
+    assert len(groups) == 2
+    # Last group must be the CacheOnly group
+    assert isinstance(groups[-1].kv_cache_spec, CacheOnlySpec)
+    assert groups[-1].layer_names == ["cache_only_0"]
+    # First group must be the two attention layers
+    assert isinstance(groups[0].kv_cache_spec, FullAttentionSpec)
+    assert set(groups[0].layer_names) == {"layer_1", "layer_2"}
+
+
+def test_get_kv_cache_groups_cache_only_hybrid():
+    """HMA path (FullAttention + Mamba) + CacheOnly: last group is CacheOnly."""
+    vllm_config = VllmConfig(model_config=ModelConfig(max_model_len=16))
+
+    attn_spec = new_kv_cache_spec(block_size=16, num_kv_heads=2, head_size=64)
+    mamba_page_size = attn_spec.page_size_bytes  # pad mamba to same page size
+    mamba_spec = new_mamba_spec(block_size=16, page_size_padded=mamba_page_size)
+    cache_only_spec = new_cache_only_spec()
+
+    kv_cache_spec = {
+        "attn_0": attn_spec,
+        "mamba_0": mamba_spec,
+        "cache_only_0": cache_only_spec,
+    }
+    groups = get_kv_cache_groups(vllm_config, kv_cache_spec)
+    assert isinstance(groups[-1].kv_cache_spec, CacheOnlySpec)
+    assert groups[-1].layer_names == ["cache_only_0"]
+    # Remaining groups come from the HMA path; neither is CacheOnly
+    for g in groups[:-1]:
+        assert not isinstance(g.kv_cache_spec, CacheOnlySpec)
+
+
+def test_get_kv_cache_groups_cache_only_excluded_from_unify():
+    """CacheOnly must be pre-extracted before unify_hybrid_kv_cache_specs runs."""
+    vllm_config = VllmConfig(model_config=ModelConfig(max_model_len=16))
+    vllm_config.scheduler_config.disable_hybrid_kv_cache_manager = True
+
+    kv_cache_spec = {
+        "layer_1": new_kv_cache_spec(),
+        "layer_2": new_sliding_window_spec(sliding_window=1),
+        "cache_only_0": new_cache_only_spec(),
+    }
+    # Should not raise even though CacheOnlySpec can't be unified
+    groups = get_kv_cache_groups(vllm_config, kv_cache_spec)
+    assert isinstance(groups[-1].kv_cache_spec, CacheOnlySpec)
+
+
+def test_get_kv_cache_config_from_groups_budget():
+    """Memory budget includes CacheOnly cost per block."""
+    vllm_config = VllmConfig(model_config=ModelConfig(max_model_len=16))
+
+    attn_spec = new_kv_cache_spec()  # page_size = 16 * 2 * 64 * 4 * 2
+    cache_only_spec = new_cache_only_spec()  # page_size = 16 * 3 * 64 * 4
+
+    attn_page = attn_spec.page_size_bytes
+    co_page = cache_only_spec.page_size_bytes
+    target_blocks = 32
+    # 2 attn layers + 1 cache_only layer
+    available_memory = target_blocks * (2 * attn_page + co_page)
+
+    groups = [
+        KVCacheGroupSpec(["layer_1", "layer_2"], attn_spec),
+        KVCacheGroupSpec(["cache_only_0"], cache_only_spec),
+    ]
+    config = get_kv_cache_config_from_groups(vllm_config, groups, available_memory)
+
+    assert config.num_blocks == target_blocks
+    assert sum(t.size for t in config.kv_cache_tensors) == available_memory
+
+    # Verify the CacheOnly tensor is sized correctly
+    co_tensors = [t for t in config.kv_cache_tensors if t.shared_by == ["cache_only_0"]]
+    assert len(co_tensors) == 1
+    assert co_tensors[0].size == co_page * target_blocks

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1251,18 +1251,29 @@ class VllmConfig:
         if self.scheduler_config.disable_hybrid_kv_cache_manager is None:
             # Default to disable HMA, but only if the user didn't express a preference.
             if self.kv_transfer_config is not None:
-                # NOTE(Kuntai): turn HMA off for connector unless specifically enabled.
-                need_disable_hybrid_kv_cache_manager = True
-                logger.warning(
-                    "Turning off hybrid kv cache manager because "
-                    "`--kv-transfer-config` is set. This will reduce the "
-                    "performance of vLLM on LLMs with sliding window attention "
-                    "or Mamba attention. If you are a developer of kv connector"
-                    ", please consider supporting hybrid kv cache manager for "
-                    "your connector by making sure your connector is a subclass"
-                    " of `SupportsHMA` defined in kv_connector/v1/base.py and"
-                    " use --no-disable-hybrid-kv-cache-manager to start vLLM."
+                from vllm.distributed.kv_transfer.kv_connector.factory import (
+                    KVConnectorFactory,
                 )
+                from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+                    supports_hma,
+                )
+
+                connector_cls = KVConnectorFactory.get_connector_class(
+                    self.kv_transfer_config
+                )
+                if not supports_hma(connector_cls):
+                    # NOTE(Kuntai): turn HMA off unless connector supports it.
+                    need_disable_hybrid_kv_cache_manager = True
+                    logger.warning(
+                        "Turning off hybrid kv cache manager because "
+                        "`--kv-transfer-config` is set. This will reduce the "
+                        "performance of vLLM on LLMs with sliding window attention "
+                        "or Mamba attention. If you are a developer of kv connector"
+                        ", please consider supporting hybrid kv cache manager for "
+                        "your connector by making sure your connector is a subclass"
+                        " of `SupportsHMA` defined in kv_connector/v1/base.py and"
+                        " use --no-disable-hybrid-kv-cache-manager to start vLLM."
+                    )
             self.scheduler_config.disable_hybrid_kv_cache_manager = (
                 need_disable_hybrid_kv_cache_manager
             )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
@@ -12,10 +12,12 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
     KVConnectorRole,
+    SupportsHMA,
 )
 from vllm.logger import init_logger
 from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
+from vllm.v1.kv_cache_interface import CacheOnlySpec
 
 if TYPE_CHECKING:
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
@@ -99,7 +101,7 @@ class ExampleHiddenStatesConnectorMetadata(KVConnectorMetadata):
         )
 
 
-class ExampleHiddenStatesConnector(KVConnectorBase_V1):
+class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
     """
     Simple debug implementation of a HiddenStatesConnector.
 
@@ -147,6 +149,16 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1):
         self._request_filenames: dict[str, str] = {}
         self._active_requests: dict[str, NewRequestData] = {}
         self._req_blocks: dict[str, list[int]] = {}
+
+        groups = kv_cache_config.kv_cache_groups if kv_cache_config is not None else []
+        self._cache_group_idx = next(
+            (
+                i
+                for i, g in enumerate(groups)
+                if isinstance(g.kv_cache_spec, CacheOnlySpec)
+            ),
+            0,
+        )
 
     # ==============================
     # Worker-side methods
@@ -269,12 +281,14 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1):
                 new_req.req_id,
                 filename=filename,
                 token_ids=token_ids,
-                block_ids=new_req.block_ids[0],
+                block_ids=new_req.block_ids[self._cache_group_idx],
                 block_size=self._block_size,
             )
             self._request_filenames[new_req.req_id] = filename
             self._active_requests[new_req.req_id] = new_req
-            self._req_blocks[new_req.req_id] = list(new_req.block_ids[0])
+            self._req_blocks[new_req.req_id] = list(
+                new_req.block_ids[self._cache_group_idx]
+            )
 
         cached_reqs = scheduler_output.scheduled_cached_reqs
         for i, req_id in enumerate(cached_reqs.req_ids):
@@ -289,7 +303,7 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1):
             if new_block_ids is None:
                 continue
 
-            block_ids = new_block_ids[0]
+            block_ids = new_block_ids[self._cache_group_idx]
 
             req_block_ids.extend(block_ids)
             filename = os.path.join(self._storage_path, f"{req_id}.safetensors")
@@ -330,6 +344,13 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1):
         _ = self._req_blocks.pop(req_id, None)
 
         return False, {"hidden_states_path": req_filename}
+
+    def request_finished_all_groups(
+        self,
+        request: "Request",
+        block_ids: tuple[list[int], ...],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        return self.request_finished(request, block_ids[self._cache_group_idx])
 
     @classmethod
     def get_required_kvcache_layout(cls, vllm_config: "VllmConfig") -> str | None:

--- a/vllm/model_executor/models/extract_hidden_states.py
+++ b/vllm/model_executor/models/extract_hidden_states.py
@@ -34,8 +34,8 @@ from vllm.v1.attention.backend import (
 )
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
+    CacheOnlySpec,
     KVCacheSpec,
-    MLAAttentionSpec,
 )
 
 ########## Custom Ops ########
@@ -322,13 +322,10 @@ class CacheOnlyAttentionLayer(nn.Module, AttentionLayerBase):
         return self.attn_backend
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
-        # Note: we use MLAAttentionSpec here to because it will
-        # produce page sizes of (block_size * num_kv_heads * head_size * dtype_size)
-        # whereas FullAttentionSpec will add an additional factor of 2
-        return MLAAttentionSpec(
+        return CacheOnlySpec(
             block_size=self.block_size,
-            num_kv_heads=self.num_heads,
-            head_size=self.head_size,
+            num_hidden_states=self.num_heads,
+            hidden_size=self.head_size,
             dtype=self.kv_cache_torch_dtype,
         )
 

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -18,6 +18,7 @@ from vllm.utils.hashing import sha256_cbor, xxhash_cbor
 from vllm.utils.math_utils import cdiv
 from vllm.utils.mem_utils import format_gib
 from vllm.v1.kv_cache_interface import (
+    CacheOnlySpec,
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
     KVCacheConfig,
@@ -1103,24 +1104,54 @@ def get_kv_cache_config_from_groups(
             kv_cache_groups=kv_cache_groups,
         )
 
+    # CacheOnly groups get their own independent tensors drawn from the same
+    # block pool. PP workers that don't own the CacheOnly layer have an empty
+    # layer_names list and are skipped here (no memory impact on that worker).
+    cache_only_groups = [
+        g
+        for g in kv_cache_groups
+        if isinstance(g.kv_cache_spec, CacheOnlySpec) and g.layer_names
+    ]
+    main_groups = [
+        g for g in kv_cache_groups if not isinstance(g.kv_cache_spec, CacheOnlySpec)
+    ]
+    # Total CacheOnly bytes consumed per block across all CacheOnly groups.
+    cache_only_bytes_per_block = sum(
+        g.kv_cache_spec.page_size_bytes for g in cache_only_groups
+    )
+
+    kv_cache_tensors: list[KVCacheTensor] = []
+
     # Determine how model runners should initialize the KV cache tensors.
-    if len(kv_cache_groups) == 1 and isinstance(
-        kv_cache_groups[0].kv_cache_spec, UniformTypeKVCacheSpecs
+    if not main_groups:
+        num_blocks = (
+            int(available_memory // cache_only_bytes_per_block)
+            if cache_only_bytes_per_block
+            else 1
+        )
+        num_blocks = may_override_num_blocks(vllm_config, num_blocks)
+    elif len(main_groups) == 1 and isinstance(
+        main_groups[0].kv_cache_spec, UniformTypeKVCacheSpecs
     ):
         # Special case: all layers have the same type of KV cache but with
         # different hidden size. Allocate different amount of memory for each
         # layer based on its hidden size.
-        num_blocks = (
-            available_memory // kv_cache_groups[0].kv_cache_spec.page_size_bytes
+        num_blocks = int(
+            available_memory
+            // (
+                main_groups[0].kv_cache_spec.page_size_bytes
+                + cache_only_bytes_per_block
+            )
         )
+        num_blocks = max(num_blocks, 0)
         num_blocks = may_override_num_blocks(vllm_config, num_blocks)
-        per_layer_specs = kv_cache_groups[0].kv_cache_spec.kv_cache_specs
+        per_layer_specs = main_groups[0].kv_cache_spec.kv_cache_specs
         kv_cache_tensors = [
             KVCacheTensor(
                 size=per_layer_specs[layer_name].page_size_bytes * num_blocks,
                 shared_by=[layer_name],
             )
-            for layer_name in kv_cache_groups[0].layer_names
+            for layer_name in main_groups[0].layer_names
         ]
     else:
         # General case:
@@ -1131,24 +1162,38 @@ def get_kv_cache_config_from_groups(
         # (sw.1, padding) will be: (group_size = 2)
         # full.0, sw.0, sw.1: share a Tensor with size=available_memory//2
         # full.1, sw.2: share another Tensor with size=available_memory//2
-        group_size = max(len(group.layer_names) for group in kv_cache_groups)
-
+        group_size = max(len(group.layer_names) for group in main_groups)
         page_size = get_uniform_page_size(
-            [group.kv_cache_spec for group in kv_cache_groups]
+            [group.kv_cache_spec for group in main_groups]
         )
         assert group_size > 0, "group_size must be greater than 0"
-        num_blocks = get_num_blocks(
-            vllm_config, group_size, available_memory, page_size
-        )
-        kv_cache_tensors = []
+        if cache_only_bytes_per_block:
+            num_blocks = int(
+                available_memory
+                // (group_size * page_size + cache_only_bytes_per_block)
+            )
+            num_blocks = max(num_blocks, 0)
+            num_blocks = may_override_num_blocks(vllm_config, num_blocks)
+        else:
+            # Preserve existing integer-division order for the no-CacheOnly path.
+            num_blocks = get_num_blocks(
+                vllm_config, group_size, available_memory, page_size
+            )
         for i in range(group_size):
-            shared_by = []
-            for j in range(len(kv_cache_groups)):
-                if i < len(kv_cache_groups[j].layer_names):
-                    shared_by.append(kv_cache_groups[j].layer_names[i])
+            shared_by = [
+                g.layer_names[i] for g in main_groups if i < len(g.layer_names)
+            ]
             kv_cache_tensors.append(
                 KVCacheTensor(size=page_size * num_blocks, shared_by=shared_by)
             )
+
+    for g in cache_only_groups:
+        kv_cache_tensors.append(
+            KVCacheTensor(
+                size=g.kv_cache_spec.page_size_bytes * num_blocks,
+                shared_by=list(g.layer_names),
+            )
+        )
 
     return KVCacheConfig(
         num_blocks=num_blocks,
@@ -1232,34 +1277,49 @@ def get_kv_cache_groups(
     Returns:
         The generated KVCacheGroups
     """
-    if vllm_config.scheduler_config.disable_hybrid_kv_cache_manager:
-        unify_hybrid_kv_cache_specs(kv_cache_spec)
+    cache_only_specs = {
+        k: v for k, v in kv_cache_spec.items() if isinstance(v, CacheOnlySpec)
+    }
+    regular_specs = {
+        k: v for k, v in kv_cache_spec.items() if not isinstance(v, CacheOnlySpec)
+    }
 
-    if is_kv_cache_type_attention_free(kv_cache_spec):
+    if vllm_config.scheduler_config.disable_hybrid_kv_cache_manager:
+        unify_hybrid_kv_cache_specs(regular_specs)
+
+    if is_kv_cache_type_attention_free(regular_specs):
         # This returns an empty list to allow for the KVCacheManager to handle
         # attention free models.
-        return []
-
-    if is_kv_cache_spec_uniform(kv_cache_spec):
+        groups: list[KVCacheGroupSpec] = []
+    elif is_kv_cache_spec_uniform(regular_specs):
         # KV cache of all layers are the same, which is true for
         # most models. Allocate the same amount of memory for
         # each layer.
-        return _get_kv_cache_groups_uniform_spec(kv_cache_spec)
-    elif uniform_spec := UniformTypeKVCacheSpecs.from_specs(kv_cache_spec):
+        groups = _get_kv_cache_groups_uniform_spec(regular_specs)
+    elif uniform_spec := UniformTypeKVCacheSpecs.from_specs(regular_specs):
         # All layers need the same number of token slots (e.g., all layers are
         # full attention, or all layers are sliding window attention with the
         # same window size). Put all layers into one group.
-        return _get_kv_cache_groups_uniform_type(uniform_spec)
+        groups = _get_kv_cache_groups_uniform_type(uniform_spec)
+    else:
+        # As KVCacheManager can only allocate memory of one size, we need to
+        # unify the page size of the layers. For cases cannot be unified, this
+        # function will raise an error.
+        regular_specs = unify_kv_cache_spec_page_size(regular_specs)
+        # Model contains multiple attention types, but KV cache of all layers
+        # have the same physical memory per block per layer. Split the layers
+        # into groups with the same number of layers, and thus same total page
+        # size.
+        groups = _get_kv_cache_groups_uniform_page_size(regular_specs)
 
-    # As KVCacheManager can only allocate memory of one size, we need to unify
-    # the page size of the layers. For cases cannot be unified, this function
-    # will raise an error.
-    kv_cache_spec = unify_kv_cache_spec_page_size(kv_cache_spec)
-    # Model contains multiple attention types, but KV cache of all layers
-    # have the same physical memory per block per layer. Split the layers
-    # into groups with the same number of layers, and thus same total page
-    # size.
-    return _get_kv_cache_groups_uniform_page_size(kv_cache_spec)
+    if cache_only_specs:
+        groups.append(
+            KVCacheGroupSpec(
+                list(cache_only_specs), next(iter(cache_only_specs.values()))
+            )
+        )
+
+    return groups
 
 
 def generate_scheduler_kv_cache_config(
@@ -1343,28 +1403,44 @@ def _max_memory_usage_bytes_from_groups(
     if not kv_cache_groups:
         return 0
 
+    cache_only_groups = [
+        g
+        for g in kv_cache_groups
+        if isinstance(g.kv_cache_spec, CacheOnlySpec) and g.layer_names
+    ]
+    main_groups = [
+        g for g in kv_cache_groups if not isinstance(g.kv_cache_spec, CacheOnlySpec)
+    ]
+    cache_only_bytes = sum(
+        g.kv_cache_spec.max_memory_usage_bytes(vllm_config) for g in cache_only_groups
+    )
+
+    if not main_groups:
+        return cache_only_bytes
+
     # UniformTypeKVCacheSpecs special case (single group, per-layer specs)
-    if len(kv_cache_groups) == 1 and isinstance(
-        kv_cache_groups[0].kv_cache_spec, UniformTypeKVCacheSpecs
+    if len(main_groups) == 1 and isinstance(
+        main_groups[0].kv_cache_spec, UniformTypeKVCacheSpecs
     ):
-        per_layer_specs = kv_cache_groups[0].kv_cache_spec.kv_cache_specs
-        return sum(
-            spec.max_memory_usage_bytes(vllm_config)
-            for spec in per_layer_specs.values()
+        per_layer_specs = main_groups[0].kv_cache_spec.kv_cache_specs
+        return (
+            sum(
+                spec.max_memory_usage_bytes(vllm_config)
+                for spec in per_layer_specs.values()
+            )
+            + cache_only_bytes
         )
 
     # General case: group_size pools, each shared by one layer per group
     # Memory = group_size * page_size * blocks_for_max_len
-    group_size = max(len(group.layer_names) for group in kv_cache_groups)
-    page_size = get_uniform_page_size(
-        [group.kv_cache_spec for group in kv_cache_groups]
-    )
+    group_size = max(len(group.layer_names) for group in main_groups)
+    page_size = get_uniform_page_size([group.kv_cache_spec for group in main_groups])
     blocks_needed = sum(
         cdiv(group.kv_cache_spec.max_memory_usage_bytes(vllm_config), page_size)
-        for group in kv_cache_groups
+        for group in main_groups
     )
 
-    return group_size * page_size * blocks_needed
+    return group_size * page_size * blocks_needed + cache_only_bytes
 
 
 def _estimate_max_model_len_from_groups(

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -13,6 +13,7 @@ from vllm.v1.core.kv_cache_utils import (
     KVCacheBlock,
 )
 from vllm.v1.kv_cache_interface import (
+    CacheOnlySpec,
     ChunkedLocalAttentionSpec,
     CrossAttentionSpec,
     FullAttentionSpec,
@@ -1106,6 +1107,36 @@ class SinkFullAttentionManager(FullAttentionManager):
         self.sink_blocks = self.block_pool.free_block_queue.popleft_n(num_sink_block)
 
 
+class CacheOnlyManager(SingleTypeKVCacheManager):
+    """Manager for CacheOnlySpec: paged hidden-state storage.
+
+    Block allocation follows the same sequential logic as the base class.
+    Prefix caching is not applicable: find_longest_cache_hit always returns
+    empty and cache_blocks is a no-op.
+    """
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        return 0
+
+    def cache_blocks(self, request: Request, num_tokens: int) -> None:
+        pass
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        use_eagle: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[list[KVCacheBlock], ...]:
+        return tuple([] for _ in kv_cache_group_ids)
+
+
 spec_manager_map: dict[type[KVCacheSpec], type[SingleTypeKVCacheManager]] = {
     FullAttentionSpec: FullAttentionManager,
     MLAAttentionSpec: FullAttentionManager,
@@ -1114,6 +1145,7 @@ spec_manager_map: dict[type[KVCacheSpec], type[SingleTypeKVCacheManager]] = {
     MambaSpec: MambaManager,
     CrossAttentionSpec: CrossAttentionManager,
     SinkFullAttentionSpec: SinkFullAttentionManager,
+    CacheOnlySpec: CacheOnlyManager,
 }
 
 

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -360,6 +360,34 @@ class MambaSpec(KVCacheSpec):
 
 
 @dataclass(frozen=True)
+class CacheOnlySpec(KVCacheSpec):
+    """
+    KV cache spec for CacheOnlyAttentionLayer used by extract_hidden_states
+    speculative decoding.
+
+    Semantically distinct from AttentionSpec: there is no key/value factor of 2,
+    and the dimensions describe hidden state slots rather than attention heads.
+    """
+
+    num_hidden_states: int
+    hidden_size: int
+    dtype: torch.dtype
+
+    @property
+    def page_size_bytes(self) -> int:
+        return (
+            self.block_size
+            * self.num_hidden_states
+            * self.hidden_size
+            * get_dtype_size(self.dtype)
+        )
+
+    def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
+        max_model_len = vllm_config.model_config.max_model_len
+        return cdiv(max_model_len, self.block_size) * self.page_size_bytes
+
+
+@dataclass(frozen=True)
 class EncoderOnlyAttentionSpec(AttentionSpec):
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
         # Encoder-only layers do not need KV cache
@@ -489,6 +517,8 @@ class UniformTypeKVCacheSpecs(KVCacheSpec):
                 and spec.num_speculative_blocks == one_spec.num_speculative_blocks
                 for spec in kv_cache_specs.values()
             )
+        elif isinstance(one_spec, CacheOnlySpec):
+            return False
         else:
             # NOTE(Chen): Please add new branches for new KV cache spec types.
             raise NotImplementedError(

--- a/vllm/v1/spec_decode/extract_hidden_states.py
+++ b/vllm/v1/spec_decode/extract_hidden_states.py
@@ -93,8 +93,9 @@ class ExtractHiddenStatesProposer:
             target_hidden_states: List of hidden state tensors from target model
                                 (one per aux hidden state layer)
             common_attn_metadata: Attention metadata
-            slot_mappings: Slot mappings for KV cache (unused, provided for
-                          interface compatibility)
+            slot_mappings: Per-layer slot mappings for KV cache; the entry
+                          for the CacheOnly layer is used to fill the hidden
+                          states into the correct paged block slots
 
         Returns:
             Tuple of:
@@ -129,6 +130,10 @@ class ExtractHiddenStatesProposer:
         if num_tokens_across_dp is not None:
             num_tokens_across_dp[self.dp_rank] = num_input_tokens
 
+        cache_only_slot_mapping = None
+        if isinstance(slot_mappings, dict) and self.attn_layer_names:
+            cache_only_slot_mapping = slot_mappings.get(self.attn_layer_names[0])
+
         with set_forward_context(
             per_layer_attn_metadata,
             self.vllm_config,
@@ -136,7 +141,7 @@ class ExtractHiddenStatesProposer:
             num_tokens_across_dp=num_tokens_across_dp,
             cudagraph_runtime_mode=cudagraph_runtime_mode,
             slot_mapping=self._get_slot_mapping(
-                num_input_tokens, common_attn_metadata.slot_mapping
+                num_input_tokens, cache_only_slot_mapping
             ),
         ):
             self.model(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -132,6 +132,7 @@ from vllm.v1.core.sched.output import NewRequestData
 from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
+    CacheOnlySpec,
     ChunkedLocalAttentionSpec,
     CrossAttentionSpec,
     EncoderOnlyAttentionSpec,
@@ -2130,7 +2131,7 @@ class GPUModelRunner(
         def _get_block_table(kv_cache_gid: int):
             assert num_reqs_padded is not None and num_tokens_padded is not None
             kv_cache_spec = kv_cache_groups[kv_cache_gid].kv_cache_spec
-            if isinstance(kv_cache_spec, EncoderOnlyAttentionSpec):
+            if isinstance(kv_cache_spec, (EncoderOnlyAttentionSpec, CacheOnlySpec)):
                 blk_table_tensor = torch.zeros(
                     (num_reqs_padded, 1),
                     dtype=torch.int32,
@@ -3723,6 +3724,14 @@ class GPUModelRunner(
                     dtype=torch.int64,
                     device=self.device,
                 )
+            elif isinstance(kv_cache_spec, CacheOnlySpec):
+                # Use real slot mapping so hidden states land in the correct
+                # paged blocks.  Fill padding with 0 (not -1): basic_cache uses
+                # plain tensor indexing and cannot handle negative slot IDs.
+                blk_table = self.input_batch.block_table[kv_cache_gid]
+                slot_mapping = blk_table.slot_mapping.gpu[:num_tokens_padded].clone()
+                slot_mapping[num_tokens_unpadded:num_tokens_padded].fill_(0)
+                return slot_mapping
             else:
                 blk_table = self.input_batch.block_table[kv_cache_gid]
                 slot_mapping = blk_table.slot_mapping.gpu[:num_tokens_padded]
@@ -6485,27 +6494,38 @@ class GPUModelRunner(
             kernel_block_sizes: The kernel block sizes for each KV cache group.
         """
         block_sizes = []
+        kernel_block_sizes_for_table = []
         max_num_blocks = []
         max_model_len = max(self.max_model_len, self.max_encoder_len)
+        # prepare_kernel_block_sizes skips CacheOnly groups, so kernel_block_sizes
+        # has no entry for them; insert block_size directly for CacheOnly instead
+        # of consuming from the iterator.
+        kernel_block_sizes_iter = iter(kernel_block_sizes)
         for kv_cache_group in kv_cache_config.kv_cache_groups:
-            if isinstance(kv_cache_group.kv_cache_spec, EncoderOnlyAttentionSpec):
+            spec = kv_cache_group.kv_cache_spec
+            if isinstance(spec, EncoderOnlyAttentionSpec):
                 continue
-            block_size = kv_cache_group.kv_cache_spec.block_size
+            block_size = spec.block_size
             block_sizes.append(block_size)
             max_num_blocks_per_req = cdiv(
                 max_model_len, block_size * get_total_cp_world_size()
             )
-            if isinstance(kv_cache_group.kv_cache_spec, MambaSpec):
+            if isinstance(spec, MambaSpec):
                 max_num_blocks_per_req = (
                     max_num_blocks_per_req
                     if self.cache_config.enable_prefix_caching
                     else 1
-                ) + kv_cache_group.kv_cache_spec.num_speculative_blocks
+                ) + spec.num_speculative_blocks
             max_num_blocks.append(max_num_blocks_per_req)
+            kernel_block_sizes_for_table.append(
+                block_size
+                if isinstance(spec, CacheOnlySpec)
+                else next(kernel_block_sizes_iter)
+            )
 
         if (
             block_sizes != self._init_block_sizes
-            or kernel_block_sizes != self._init_kernel_block_sizes
+            or kernel_block_sizes_for_table != self._init_kernel_block_sizes
         ):
             assert self.offload_config.uva.cpu_offload_gb == 0, (
                 "Cannot re-initialize the input batch when CPU weight "
@@ -6513,7 +6533,7 @@ class GPUModelRunner(
                 "for more details."
             )
             self._init_block_sizes = block_sizes
-            self._init_kernel_block_sizes = kernel_block_sizes
+            self._init_kernel_block_sizes = kernel_block_sizes_for_table
             self.input_batch = InputBatch(
                 max_num_reqs=self.max_num_reqs,
                 max_model_len=max_model_len,
@@ -6522,7 +6542,7 @@ class GPUModelRunner(
                 pin_memory=self.pin_memory,
                 vocab_size=self.model_config.get_vocab_size(),
                 block_sizes=block_sizes,
-                kernel_block_sizes=kernel_block_sizes,
+                kernel_block_sizes=kernel_block_sizes_for_table,
                 max_num_blocks_per_req=max_num_blocks,
                 is_spec_decode=bool(self.vllm_config.speculative_config),
                 logitsprocs=self.input_batch.logitsprocs,
@@ -6534,9 +6554,9 @@ class GPUModelRunner(
             f"InputBatch block_sizes {self._init_block_sizes} != "
             f"kv_cache block_sizes {block_sizes}"
         )
-        assert self._init_kernel_block_sizes == kernel_block_sizes, (
+        assert self._init_kernel_block_sizes == kernel_block_sizes_for_table, (
             f"InputBatch kernel_block_sizes {self._init_kernel_block_sizes} "
-            f"!= kv_cache kernel_block_sizes {kernel_block_sizes}"
+            f"!= kv_cache kernel_block_sizes {kernel_block_sizes_for_table}"
         )
 
     def _allocate_kv_cache_tensors(
@@ -6603,17 +6623,27 @@ class GPUModelRunner(
         for group in self._kv_cache_spec_attn_group_iterator():
             kv_cache_spec = group.kv_cache_spec
             attn_backend = group.backend
-            if group.kv_cache_group_id == len(kernel_block_sizes):
-                # There may be a last group for layers without kv cache.
+            is_cache_only = isinstance(kv_cache_spec, CacheOnlySpec)
+            if group.kv_cache_group_id == len(kernel_block_sizes) and not is_cache_only:
+                # Group without kv cache (e.g. encoder-only on some workers)
                 continue
-            kernel_block_size = kernel_block_sizes[group.kv_cache_group_id]
+            kernel_block_size = (
+                None if is_cache_only else kernel_block_sizes[group.kv_cache_group_id]
+            )
             for layer_name in group.layer_names:
                 if layer_name in self.runner_only_attn_layers:
                     continue
                 raw_tensor = kv_cache_raw_tensors[layer_name]
                 assert raw_tensor.numel() % kv_cache_spec.page_size_bytes == 0
                 num_blocks = raw_tensor.numel() // kv_cache_spec.page_size_bytes
-                if isinstance(kv_cache_spec, AttentionSpec):
+                if is_cache_only:
+                    kv_caches[layer_name] = raw_tensor.view(kv_cache_spec.dtype).view(
+                        num_blocks,
+                        kv_cache_spec.block_size,
+                        kv_cache_spec.num_hidden_states,
+                        kv_cache_spec.hidden_size,
+                    )
+                elif isinstance(kv_cache_spec, AttentionSpec):
                     has_attn = True
                     num_blocks_per_kv_block = (
                         kv_cache_spec.block_size // kernel_block_size

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -25,6 +25,7 @@ from vllm.v1.attention.backend import (
 )
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
+    CacheOnlySpec,
     EncoderOnlyAttentionSpec,
     FullAttentionSpec,
     KVCacheConfig,
@@ -350,7 +351,7 @@ def prepare_kernel_block_sizes(
             # All layers in the UniformTypeKVCacheSpecs have the same type,
             # pick an arbitrary one to dispatch.
             kv_cache_spec = next(iter(kv_cache_spec.kv_cache_specs.values()))
-        if isinstance(kv_cache_spec, EncoderOnlyAttentionSpec):
+        if isinstance(kv_cache_spec, (EncoderOnlyAttentionSpec, CacheOnlySpec)):
             continue
         if isinstance(kv_cache_spec, AttentionSpec):
             # This is an attention backend that supports virtual block splitting.


### PR DESCRIPTION
This PR adds support for extracting hidden states with Hybrid Attention Models (for example: `Qwen/Qwen3.5-9B`) 

The core issue was that `CacheOnlyAttentionLayer` — the single-layer "draft model"
used by `extract_hidden_states` — was previously registered with `MLAAttentionSpec`. 
This caused two compounding bugs:

 **HMA was unconditionally disabled** when any `kv_transfer_config` was set. With
   `MLAAttentionSpec`, the CacheOnly layer appeared as a regular attention layer,
   causing `unify_hybrid_kv_cache_specs` to fail on hybrid models (Qwen3.5,
   Gemma4) where attention types cannot be unified. Even when HMA was turned on
   unification with `MLAAttentionSpec` was not guaranteed to succeed. (failed for Gemma)


A dedicated `CacheOnlySpec(KVCacheSpec)` is introduced with semantics that match
hidden-state storage:

```
page_size_bytes = block_size × num_hidden_states × hidden_size × dtype_size_bytes
```

Because `CacheOnlySpec` does **not** inherit from `AttentionSpec`, all existing
`isinstance(spec, AttentionSpec)` guards naturally exclude it, and it is routed
through a dedicated code path in each subsystem.

### Memory budget

`CacheOnlySpec` groups are pre-extracted from the main spec map before routing.
`get_kv_cache_config_from_groups` deducts their memory cost from the shared pool:

```
num_blocks = floor(available_memory / (main_bytes_per_block + cache_only_bytes_per_block))
```

Both the main KV cache tensors and the CacheOnly tensor are allocated for the same
`num_blocks`, ensuring that any block ID valid for the main cache is also valid for
the CacheOnly cache. The CacheOnly tensor is given its own independent `KVCacheTensor`
entry (not shared with attention layers).


### HMA interaction

`ExampleHiddenStatesConnector` now declares `SupportsHMA`. The `VllmConfig` post-init
check uses this to skip the blanket HMA-disable that would otherwise fire whenever a
`kv_transfer_config` is present. Keeping HMA enabled is required for hybrid models
(sliding-window attention, Mamba) to use their separate KV cache groups correctly.

---

<details>
<summary><strong>High level description of each change</strong></summary>

| File | Change |
|---|---|
| `vllm/v1/kv_cache_interface.py` | Add `CacheOnlySpec`; guard `UniformTypeKVCacheSpecs.is_uniform_type` against it |
| `vllm/v1/core/single_type_kv_cache_manager.py` | Add `CacheOnlyManager` (prefix cache disabled); register in `spec_manager_map` |
| `vllm/v1/core/kv_cache_utils.py` | Isolate CacheOnly groups before routing in `get_kv_cache_groups`; account for CacheOnly memory in `get_kv_cache_config_from_groups` and `_max_memory_usage_bytes_from_groups` |
| `vllm/model_executor/models/extract_hidden_states.py` | Return `CacheOnlySpec` from `get_kv_cache_spec()` instead of `MLAAttentionSpec` |
| `vllm/v1/worker/gpu_model_runner.py` | Add CacheOnly branch in `_get_slot_mappings` (real block table, 0-padded); add CacheOnly to block table in `_reinitialize_input_batch` via `iter(kernel_block_sizes)` decoupling |
| `vllm/v1/spec_decode/extract_hidden_states.py` | Extract per-layer `cache_only_slot_mapping` from the full `slot_mappings` dict in `propose()` |
| `vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py` | Declare `SupportsHMA`; detect CacheOnly group index dynamically via `_cache_group_idx`; add `request_finished_all_groups`; fix `block_ids` indexing to use `_cache_group_idx` |
| `vllm/config/vllm.py` | Gate HMA-disable behind `supports_hma()` check so connectors implementing `SupportsHMA` keep HMA enabled |
| `tests/v1/core/test_kv_cache_utils.py` | 5 new unit tests covering `CacheOnlySpec` page size, group routing, and memory budget |

</details>

---

## Test plan

### Unit tests

```bash
.venv/bin/python -m pytest tests/v1/core/test_kv_cache_utils.py \
  -k "cache_only" -v
```

### Manual end-to-end verification

Manually verified with `examples/offline_inference/extract_hidden_states.py` on both
a non-hybrid and a hybrid model:

**Hybrid (non-uniform attention):**
```
model="Qwen/Qwen3.5-9B", tensor_parallel_size=4
eagle_aux_hidden_state_layer_ids=[1, 2, 3, 4]
```

**Non-hybrid (uniform full attention):**
```
model="Qwen/Qwen3-8B", tensor_parallel_size=4
eagle_aux_hidden_state_layer_ids=[1, 2, 3, 4]
```

Both runs produced correctly shaped `hidden_states` tensors saved to safetensors, with
`token_ids` matching the prompt token IDs.

---

## Checklist

- [ ] All new code paths have corresponding unit tests
- [x] Existing test suite unaffected (new code paths gated behind `isinstance(spec, CacheOnlySpec)`)
- [x] Pre-commit hooks pass on all touched files
- [x] Manual end-to-end verification on non-hybrid and hybrid models
- [x] AI assistance used (Claude); all changed lines reviewed by human submitter
