### PR TITLE
[RFC] Hybrid model ExtractHiddenStates: CacheOnly as filtered KV cache group

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -38,6 +38,7 @@ from vllm.v1.core.kv_cache_utils import (
     tensor_data,
 )
 from vllm.v1.kv_cache_interface import (
+    CacheOnlySpec,
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
     KVCacheConfig,
@@ -2165,3 +2166,81 @@ def test_hma_not_disabled_when_kv_events_enabled():
     assert vllm_config.scheduler_config.disable_hybrid_kv_cache_manager is False, (
         "kv_events_config must not force-disable the hybrid KV cache manager."
     )
+
+
+def new_cache_only_spec(
+    block_size=16,
+    num_kv_heads=4,
+    head_size=128,
+    dtype=torch.float32,
+):
+    return CacheOnlySpec(
+        block_size=block_size,
+        num_kv_heads=num_kv_heads,
+        head_size=head_size,
+        dtype=dtype,
+    )
+
+
+def test_get_kv_cache_groups_cache_only_pure_attention():
+    """CacheOnly should be appended as the last group with pure attention."""
+    vllm_config = VllmConfig(model_config=ModelConfig(max_model_len=16))
+    kv_cache_spec = {
+        "layer_0": new_kv_cache_spec(),
+        "layer_1": new_kv_cache_spec(),
+        "cache_layer": new_cache_only_spec(),
+    }
+    groups = kv_cache_utils.get_kv_cache_groups(vllm_config, kv_cache_spec)
+    # Main group first, CacheOnly last
+    assert len(groups) == 2
+    assert "layer_0" in groups[0].layer_names
+    assert "layer_1" in groups[0].layer_names
+    assert groups[1].layer_names == ["cache_layer"]
+    assert isinstance(groups[1].kv_cache_spec, CacheOnlySpec)
+
+
+def test_get_kv_cache_groups_cache_only_excluded_from_unify():
+    """CacheOnly should not crash unify_hybrid_kv_cache_specs."""
+    vllm_config = VllmConfig(model_config=ModelConfig(max_model_len=16))
+    vllm_config.scheduler_config.disable_hybrid_kv_cache_manager = True
+    kv_cache_spec = {
+        "layer_0": new_kv_cache_spec(),
+        "layer_1": new_sliding_window_spec(),
+        "cache_layer": new_cache_only_spec(),
+    }
+    # Should not raise — CacheOnly is pre-filtered before unification
+    groups = kv_cache_utils.get_kv_cache_groups(vllm_config, kv_cache_spec)
+    # Main layers unified into one group + CacheOnly group
+    assert len(groups) == 2
+    assert groups[-1].layer_names == ["cache_layer"]
+    assert isinstance(groups[-1].kv_cache_spec, CacheOnlySpec)
+
+
+def test_get_kv_cache_config_from_groups_budget():
+    """Memory budget should account for CacheOnly bytes per block."""
+    vllm_config = VllmConfig(model_config=ModelConfig(max_model_len=16))
+
+    main_spec = new_kv_cache_spec()
+    cache_spec = new_cache_only_spec()
+
+    main_page = main_spec.page_size_bytes  # 16 * 2 * 64 * 4 * 2 = 16384
+    cache_page = cache_spec.page_size_bytes  # 16 * 4 * 128 * 4 = 32768
+
+    # 2 main layers in one group: group_size=2, total main = 2 * main_page
+    # 1 cache_only layer: cache_page
+    # bytes_per_block = 2 * main_page + cache_page
+    available = (2 * main_page + cache_page) * 10  # room for 10 blocks
+    groups = [
+        KVCacheGroupSpec(["layer_0", "layer_1"], main_spec),
+        KVCacheGroupSpec(["cache_layer"], cache_spec),
+    ]
+    config = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config, groups, available
+    )
+    assert config.num_blocks == 10
+    # 2 main tensors + 1 cache_only tensor
+    assert len(config.kv_cache_tensors) == 3
+    assert config.kv_cache_tensors[0].size == main_page * 10
+    assert config.kv_cache_tensors[1].size == main_page * 10
+    assert config.kv_cache_tensors[2].size == cache_page * 10
+    assert config.kv_cache_tensors[2].shared_by == ["cache_layer"]

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1289,18 +1289,32 @@ class VllmConfig:
         if self.scheduler_config.disable_hybrid_kv_cache_manager is None:
             # Default to disable HMA, but only if the user didn't express a preference.
             if self.kv_transfer_config is not None:
-                # NOTE(Kuntai): turn HMA off for connector unless specifically enabled.
-                need_disable_hybrid_kv_cache_manager = True
-                logger.warning(
-                    "Turning off hybrid kv cache manager because "
-                    "`--kv-transfer-config` is set. This will reduce the "
-                    "performance of vLLM on LLMs with sliding window attention "
-                    "or Mamba attention. If you are a developer of kv connector"
-                    ", please consider supporting hybrid kv cache manager for "
-                    "your connector by making sure your connector is a subclass"
-                    " of `SupportsHMA` defined in kv_connector/v1/base.py and"
-                    " use --no-disable-hybrid-kv-cache-manager to start vLLM."
+                # Only disable HMA if the connector does not support it.
+                from vllm.distributed.kv_transfer.kv_connector.factory import (
+                    KVConnectorFactory,
                 )
+                from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+                    supports_hma,
+                )
+
+                connector_cls = KVConnectorFactory.get_connector_class(
+                    self.kv_transfer_config
+                )
+                if not supports_hma(connector_cls):
+                    need_disable_hybrid_kv_cache_manager = True
+                    logger.warning(
+                        "Turning off hybrid kv cache manager because "
+                        "`--kv-transfer-config` is set and the connector %s "
+                        "does not support HMA. This will reduce the "
+                        "performance of vLLM on LLMs with sliding window "
+                        "attention or Mamba attention. If you are a developer "
+                        "of kv connector, please consider supporting hybrid "
+                        "kv cache manager for your connector by making sure "
+                        "your connector is a subclass of `SupportsHMA` "
+                        "defined in kv_connector/v1/base.py and use "
+                        "--no-disable-hybrid-kv-cache-manager to start vLLM.",
+                        connector_cls.__name__,
+                    )
             self.scheduler_config.disable_hybrid_kv_cache_manager = (
                 need_disable_hybrid_kv_cache_manager
             )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
@@ -12,6 +12,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
     KVConnectorRole,
+    SupportsHMA,
 )
 from vllm.logger import init_logger
 from vllm.v1.attention.backend import AttentionMetadata
@@ -99,7 +100,7 @@ class ExampleHiddenStatesConnectorMetadata(KVConnectorMetadata):
         )
 
 
-class ExampleHiddenStatesConnector(KVConnectorBase_V1):
+class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
     """
     Simple debug implementation of a HiddenStatesConnector.
 
@@ -143,6 +144,27 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1):
         self.num_hidden_states = len(
             getattr(spec_config, "eagle_aux_hidden_state_layer_ids", [])
         )
+
+        # Detect which KV cache group holds the CacheOnly layer.
+        from vllm.v1.kv_cache_interface import CacheOnlySpec
+
+        groups = kv_cache_config.kv_cache_groups if kv_cache_config is not None else []
+        cache_only_idx = next(
+            (
+                i
+                for i, g in enumerate(groups)
+                if isinstance(g.kv_cache_spec, CacheOnlySpec)
+            ),
+            None,
+        )
+        if cache_only_idx is None and kv_cache_config is not None:
+            raise RuntimeError(
+                "ExampleHiddenStatesConnector requires a CacheOnlySpec group"
+            )
+        # cache_only_idx is guaranteed non-None when kv_cache_config is
+        # provided (worker context).  Scheduler-side instantiation passes
+        # kv_cache_config=None, so default to 0.
+        self._cache_group_idx: int = cache_only_idx if cache_only_idx is not None else 0
 
         self._request_filenames: dict[str, str] = {}
         self._active_requests: dict[str, NewRequestData] = {}
@@ -269,12 +291,14 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1):
                 new_req.req_id,
                 filename=filename,
                 token_ids=token_ids,
-                block_ids=new_req.block_ids[0],
+                block_ids=new_req.block_ids[self._cache_group_idx],
                 block_size=self._block_size,
             )
             self._request_filenames[new_req.req_id] = filename
             self._active_requests[new_req.req_id] = new_req
-            self._req_blocks[new_req.req_id] = list(new_req.block_ids[0])
+            self._req_blocks[new_req.req_id] = list(
+                new_req.block_ids[self._cache_group_idx]
+            )
 
         cached_reqs = scheduler_output.scheduled_cached_reqs
         for i, req_id in enumerate(cached_reqs.req_ids):
@@ -289,7 +313,7 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1):
             if new_block_ids is None:
                 continue
 
-            block_ids = new_block_ids[0]
+            block_ids = new_block_ids[self._cache_group_idx]
 
             req_block_ids.extend(block_ids)
             filename = os.path.join(self._storage_path, f"{req_id}.safetensors")
@@ -330,6 +354,13 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1):
         _ = self._req_blocks.pop(req_id, None)
 
         return False, {"hidden_states_path": req_filename}
+
+    def request_finished_all_groups(
+        self,
+        request: "Request",
+        block_ids: tuple[list[int], ...],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        return self.request_finished(request, block_ids[self._cache_group_idx])
 
     @classmethod
     def get_required_kvcache_layout(cls, vllm_config: "VllmConfig") -> str | None:

--- a/vllm/model_executor/models/extract_hidden_states.py
+++ b/vllm/model_executor/models/extract_hidden_states.py
@@ -34,8 +34,8 @@ from vllm.v1.attention.backend import (
 )
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
+    CacheOnlySpec,
     KVCacheSpec,
-    MLAAttentionSpec,
 )
 
 ########## Custom Ops ########
@@ -322,10 +322,7 @@ class CacheOnlyAttentionLayer(nn.Module, AttentionLayerBase):
         return self.attn_backend
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
-        # Note: we use MLAAttentionSpec here to because it will
-        # produce page sizes of (block_size * num_kv_heads * head_size * dtype_size)
-        # whereas FullAttentionSpec will add an additional factor of 2
-        return MLAAttentionSpec(
+        return CacheOnlySpec(
             block_size=self.block_size,
             num_kv_heads=self.num_heads,
             head_size=self.head_size,

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -18,6 +18,7 @@ from vllm.utils.hashing import sha256_cbor, xxhash_cbor
 from vllm.utils.math_utils import cdiv
 from vllm.utils.mem_utils import format_gib
 from vllm.v1.kv_cache_interface import (
+    CacheOnlySpec,
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
     KVCacheConfig,
@@ -837,7 +838,11 @@ def may_override_num_blocks(vllm_config: VllmConfig, num_blocks: int) -> int:
 
 
 def get_num_blocks(
-    vllm_config: VllmConfig, num_layers: int, available_memory: int, page_size: int
+    vllm_config: VllmConfig,
+    num_layers: int,
+    available_memory: int,
+    page_size: int,
+    extra_bytes_per_block: int = 0,
 ) -> int:
     """
     Get the number of kv cache blocks.
@@ -847,8 +852,11 @@ def get_num_blocks(
         num_layers: The number of layers
         available_memory: Memory available for KV cache in bytes.
         page_size: The page size of the KV cache.
+        extra_bytes_per_block: Additional per-block overhead (e.g. CacheOnly
+            groups) to include in the budget denominator.
     """
-    num_blocks = int(available_memory // page_size // num_layers)
+    bytes_per_block = page_size * num_layers + extra_bytes_per_block
+    num_blocks = int(available_memory // bytes_per_block)
     num_blocks = max(num_blocks, 0)
     num_blocks = may_override_num_blocks(vllm_config, num_blocks)
     return num_blocks
@@ -1103,52 +1111,77 @@ def get_kv_cache_config_from_groups(
             kv_cache_groups=kv_cache_groups,
         )
 
+    # Separate CacheOnly groups — they have a different page_size and
+    # must not participate in get_uniform_page_size / UniformTypeKVCacheSpecs.
+    cache_only_groups = [
+        group
+        for group in kv_cache_groups
+        if isinstance(group.kv_cache_spec, CacheOnlySpec)
+    ]
+    main_groups = [
+        group
+        for group in kv_cache_groups
+        if not isinstance(group.kv_cache_spec, CacheOnlySpec)
+    ]
+    cache_only_bytes_per_block = sum(
+        group.kv_cache_spec.page_size_bytes for group in cache_only_groups
+    )
+
     # Determine how model runners should initialize the KV cache tensors.
-    if len(kv_cache_groups) == 1 and isinstance(
-        kv_cache_groups[0].kv_cache_spec, UniformTypeKVCacheSpecs
+    # The num_blocks calculation includes cache_only_bytes_per_block so that
+    # CacheOnly tensors share the same block pool as main tensors.
+    if len(main_groups) == 1 and isinstance(
+        main_groups[0].kv_cache_spec, UniformTypeKVCacheSpecs
     ):
-        # Special case: all layers have the same type of KV cache but with
-        # different hidden size. Allocate different amount of memory for each
-        # layer based on its hidden size.
-        num_blocks = (
-            available_memory // kv_cache_groups[0].kv_cache_spec.page_size_bytes
-        )
+        # Special case: all main layers have the same type of KV cache but
+        # with different hidden size. Allocate different amount of memory for
+        # each layer based on its hidden size.
+        main_bytes = main_groups[0].kv_cache_spec.page_size_bytes
+        num_blocks = int(available_memory // (main_bytes + cache_only_bytes_per_block))
         num_blocks = may_override_num_blocks(vllm_config, num_blocks)
-        per_layer_specs = kv_cache_groups[0].kv_cache_spec.kv_cache_specs
+        per_layer_specs = main_groups[0].kv_cache_spec.kv_cache_specs
         kv_cache_tensors = [
             KVCacheTensor(
                 size=per_layer_specs[layer_name].page_size_bytes * num_blocks,
                 shared_by=[layer_name],
             )
-            for layer_name in kv_cache_groups[0].layer_names
+            for layer_name in main_groups[0].layer_names
         ]
     else:
         # General case:
-        # We will have group_size memory pools, each is shared by one layer from
-        # each group. As layers of different groups have different block table,
-        # they will use different parts of the shared Tensor.
-        # The memory layout for 3 groups (full.0, full.1), (sw.0, sw.2),
-        # (sw.1, padding) will be: (group_size = 2)
-        # full.0, sw.0, sw.1: share a Tensor with size=available_memory//2
-        # full.1, sw.2: share another Tensor with size=available_memory//2
-        group_size = max(len(group.layer_names) for group in kv_cache_groups)
-
+        # We will have group_size memory pools, each is shared by one layer
+        # from each group. As layers of different groups have different block
+        # table, they will use different parts of the shared Tensor.
+        group_size = max(len(group.layer_names) for group in main_groups)
         page_size = get_uniform_page_size(
-            [group.kv_cache_spec for group in kv_cache_groups]
+            [group.kv_cache_spec for group in main_groups]
         )
         assert group_size > 0, "group_size must be greater than 0"
         num_blocks = get_num_blocks(
-            vllm_config, group_size, available_memory, page_size
+            vllm_config,
+            group_size,
+            available_memory,
+            page_size,
+            extra_bytes_per_block=cache_only_bytes_per_block,
         )
         kv_cache_tensors = []
         for i in range(group_size):
             shared_by = []
-            for j in range(len(kv_cache_groups)):
-                if i < len(kv_cache_groups[j].layer_names):
-                    shared_by.append(kv_cache_groups[j].layer_names[i])
+            for j in range(len(main_groups)):
+                if i < len(main_groups[j].layer_names):
+                    shared_by.append(main_groups[j].layer_names[i])
             kv_cache_tensors.append(
                 KVCacheTensor(size=page_size * num_blocks, shared_by=shared_by)
             )
+
+    # Add CacheOnly tensors (each gets its own tensor with its own page_size).
+    for group in cache_only_groups:
+        kv_cache_tensors.append(
+            KVCacheTensor(
+                size=group.kv_cache_spec.page_size_bytes * num_blocks,
+                shared_by=group.layer_names,
+            )
+        )
 
     return KVCacheConfig(
         num_blocks=num_blocks,
@@ -1232,34 +1265,47 @@ def get_kv_cache_groups(
     Returns:
         The generated KVCacheGroups
     """
-    if vllm_config.scheduler_config.disable_hybrid_kv_cache_manager:
-        unify_hybrid_kv_cache_specs(kv_cache_spec)
+    cache_only = {
+        k: v for k, v in kv_cache_spec.items() if isinstance(v, CacheOnlySpec)
+    }
+    regular = {
+        k: v for k, v in kv_cache_spec.items() if not isinstance(v, CacheOnlySpec)
+    }
 
-    if is_kv_cache_type_attention_free(kv_cache_spec):
+    if vllm_config.scheduler_config.disable_hybrid_kv_cache_manager:
+        unify_hybrid_kv_cache_specs(regular)
+
+    if is_kv_cache_type_attention_free(regular):
         # This returns an empty list to allow for the KVCacheManager to handle
         # attention free models.
-        return []
-
-    if is_kv_cache_spec_uniform(kv_cache_spec):
+        groups: list[KVCacheGroupSpec] = []
+    elif is_kv_cache_spec_uniform(regular):
         # KV cache of all layers are the same, which is true for
         # most models. Allocate the same amount of memory for
         # each layer.
-        return _get_kv_cache_groups_uniform_spec(kv_cache_spec)
-    elif uniform_spec := UniformTypeKVCacheSpecs.from_specs(kv_cache_spec):
+        groups = _get_kv_cache_groups_uniform_spec(regular)
+    elif uniform_spec := UniformTypeKVCacheSpecs.from_specs(regular):
         # All layers need the same number of token slots (e.g., all layers are
         # full attention, or all layers are sliding window attention with the
         # same window size). Put all layers into one group.
-        return _get_kv_cache_groups_uniform_type(uniform_spec)
+        groups = _get_kv_cache_groups_uniform_type(uniform_spec)
+    else:
+        # As KVCacheManager can only allocate memory of one size, we need to
+        # unify the page size of the layers. For cases cannot be unified, this
+        # function will raise an error.
+        regular = unify_kv_cache_spec_page_size(regular)
+        # Model contains multiple attention types, but KV cache of all layers
+        # have the same physical memory per block per layer. Split the layers
+        # into groups with the same number of layers, and thus same total page
+        # size.
+        groups = _get_kv_cache_groups_uniform_page_size(regular)
 
-    # As KVCacheManager can only allocate memory of one size, we need to unify
-    # the page size of the layers. For cases cannot be unified, this function
-    # will raise an error.
-    kv_cache_spec = unify_kv_cache_spec_page_size(kv_cache_spec)
-    # Model contains multiple attention types, but KV cache of all layers
-    # have the same physical memory per block per layer. Split the layers
-    # into groups with the same number of layers, and thus same total page
-    # size.
-    return _get_kv_cache_groups_uniform_page_size(kv_cache_spec)
+    if cache_only:
+        groups.append(
+            KVCacheGroupSpec(list(cache_only.keys()), next(iter(cache_only.values())))
+        )
+
+    return groups
 
 
 def generate_scheduler_kv_cache_config(
@@ -1343,28 +1389,44 @@ def _max_memory_usage_bytes_from_groups(
     if not kv_cache_groups:
         return 0
 
+    cache_only_groups = [
+        g for g in kv_cache_groups if isinstance(g.kv_cache_spec, CacheOnlySpec)
+    ]
+    main_groups = [
+        g for g in kv_cache_groups if not isinstance(g.kv_cache_spec, CacheOnlySpec)
+    ]
+
     # UniformTypeKVCacheSpecs special case (single group, per-layer specs)
-    if len(kv_cache_groups) == 1 and isinstance(
-        kv_cache_groups[0].kv_cache_spec, UniformTypeKVCacheSpecs
+    if len(main_groups) == 1 and isinstance(
+        main_groups[0].kv_cache_spec, UniformTypeKVCacheSpecs
     ):
-        per_layer_specs = kv_cache_groups[0].kv_cache_spec.kv_cache_specs
-        return sum(
+        per_layer_specs = main_groups[0].kv_cache_spec.kv_cache_specs
+        main_memory = sum(
             spec.max_memory_usage_bytes(vllm_config)
             for spec in per_layer_specs.values()
         )
+    else:
+        # General case: group_size pools, each shared by one layer per group
+        # Memory = group_size * page_size * blocks_for_max_len
+        group_size = max(len(group.layer_names) for group in main_groups)
+        page_size = get_uniform_page_size(
+            [group.kv_cache_spec for group in main_groups]
+        )
+        blocks_needed = sum(
+            cdiv(
+                group.kv_cache_spec.max_memory_usage_bytes(vllm_config),
+                page_size,
+            )
+            for group in main_groups
+        )
+        main_memory = group_size * page_size * blocks_needed
 
-    # General case: group_size pools, each shared by one layer per group
-    # Memory = group_size * page_size * blocks_for_max_len
-    group_size = max(len(group.layer_names) for group in kv_cache_groups)
-    page_size = get_uniform_page_size(
-        [group.kv_cache_spec for group in kv_cache_groups]
-    )
-    blocks_needed = sum(
-        cdiv(group.kv_cache_spec.max_memory_usage_bytes(vllm_config), page_size)
-        for group in kv_cache_groups
+    # Add CacheOnly memory (shares the same block pool as main).
+    cache_only_memory = sum(
+        g.kv_cache_spec.max_memory_usage_bytes(vllm_config) for g in cache_only_groups
     )
 
-    return group_size * page_size * blocks_needed
+    return main_memory + cache_only_memory
 
 
 def _estimate_max_model_len_from_groups(

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -13,6 +13,7 @@ from vllm.v1.core.kv_cache_utils import (
     KVCacheBlock,
 )
 from vllm.v1.kv_cache_interface import (
+    CacheOnlySpec,
     ChunkedLocalAttentionSpec,
     CrossAttentionSpec,
     FullAttentionSpec,
@@ -1117,6 +1118,7 @@ spec_manager_map: dict[type[KVCacheSpec], type[SingleTypeKVCacheManager]] = {
     FullAttentionSpec: FullAttentionManager,
     TQFullAttentionSpec: FullAttentionManager,
     MLAAttentionSpec: FullAttentionManager,
+    CacheOnlySpec: FullAttentionManager,
     SlidingWindowSpec: SlidingWindowManager,
     ChunkedLocalAttentionSpec: ChunkedLocalAttentionManager,
     MambaSpec: MambaManager,

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -310,6 +310,18 @@ class MLAAttentionSpec(FullAttentionSpec):
         )
 
 
+@dataclass(frozen=True)
+class CacheOnlySpec(MLAAttentionSpec):
+    """KV cache spec for hidden-state-only storage (no attention computation).
+
+    Inherits from MLAAttentionSpec so that gpu_model_runner.py handles it
+    via existing AttentionSpec code paths. Pre-filtered by get_kv_cache_groups()
+    before any type-unification routing.
+    """
+
+    pass
+
+
 @dataclass(frozen=True, kw_only=True)
 class ChunkedLocalAttentionSpec(AttentionSpec):
     attention_chunk_size: int

--- a/vllm/v1/spec_decode/extract_hidden_states.py
+++ b/vllm/v1/spec_decode/extract_hidden_states.py
@@ -129,6 +129,11 @@ class ExtractHiddenStatesProposer:
         if num_tokens_across_dp is not None:
             num_tokens_across_dp[self.dp_rank] = num_input_tokens
 
+        # Use the CacheOnly group's slot_mapping (not the main attention
+        # group's from common_attn_metadata) since HMA gives each group
+        # its own block table.
+        cache_only_slot_mapping = self._resolve_slot_mapping(slot_mappings)
+
         with set_forward_context(
             per_layer_attn_metadata,
             self.vllm_config,
@@ -136,7 +141,7 @@ class ExtractHiddenStatesProposer:
             num_tokens_across_dp=num_tokens_across_dp,
             cudagraph_runtime_mode=cudagraph_runtime_mode,
             slot_mapping=self._get_slot_mapping(
-                num_input_tokens, common_attn_metadata.slot_mapping
+                num_input_tokens, cache_only_slot_mapping
             ),
         ):
             self.model(
@@ -149,6 +154,23 @@ class ExtractHiddenStatesProposer:
         # shape [batch_size, 2] (target + spec verification); slice to
         # return only the target-sampled column.
         return sampled_token_ids[:, :1]
+
+    def _resolve_slot_mapping(
+        self,
+        slot_mappings: dict[str, torch.Tensor]
+        | list[dict[str, torch.Tensor]]
+        | None = None,
+    ) -> torch.Tensor | None:
+        """Pick the CacheOnly layer's slot_mapping from per-layer mappings.
+
+        With HMA each group has its own block table, so the CacheOnly group
+        needs its own slot_mapping rather than the main group's.
+        """
+        if slot_mappings is None:
+            return None
+        layer_name = self.attn_layer_names[0]
+        mapping = slot_mappings[0] if isinstance(slot_mappings, list) else slot_mappings
+        return mapping[layer_name]
 
     def _get_slot_mapping(
         self,

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -25,6 +25,7 @@ from vllm.v1.attention.backend import (
 )
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
+    CacheOnlySpec,
     EncoderOnlyAttentionSpec,
     FullAttentionSpec,
     KVCacheConfig,
@@ -121,6 +122,8 @@ class KVBlockZeroer:
         for group in attn_groups_iter:
             spec = group.kv_cache_spec
             if not isinstance(spec, FullAttentionSpec):
+                continue
+            if isinstance(spec, CacheOnlySpec):
                 continue
             if group.kv_cache_group_id >= len(kernel_block_sizes):
                 continue


### PR DESCRIPTION
## Summary

- Adds hybrid model support (e.g. Qwen3.5) for `extract_hidden_states` speculative decoding by modeling CacheOnly as its own KV cache group, filtered from page-size uniformity checks and group coordination
- `CacheOnlySpec(MLAAttentionSpec)` is pre-filtered in `get_kv_cache_groups()` before type-unification, then appended as a separate group with joint memory budget accounting
- Gates HMA disable with `supports_hma()` check so hybrid models keep per-group block allocators when the connector supports it

**This is 1 of 3 alternative approaches** — see [RFC document](https://github.com/neuralmagic/vllm/blob/hma/extract-hidden-states-filtered-group/local/explanation/hybrid_hidden_states_rfc.md) and sister PRs for comparison:
- **Approach A (this PR):** CacheOnly as filtered KV cache group (9 files, +300/-78)
- **Approach B:** CacheOnly as supplementary tensors — #TBD
- **Approach C:** Bypass KV cache entirely — #TBD

## Test plan

- [ ] Verified on Qwen3.5-9B with TP=4, non-zero hidden states extracted
- [ ] Verified on standard (non-hybrid) model — no regression
- [ ] `pre-commit run --all-files` passes on changed files
- [ ] Unit tests added in `tests/v1/core/test_kv_cache_utils.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)