### PR TITLE
[RFC] Hybrid model ExtractHiddenStates: CacheOnly as supplementary tensors

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -38,6 +38,7 @@ from vllm.v1.core.kv_cache_utils import (
     tensor_data,
 )
 from vllm.v1.kv_cache_interface import (
+    CacheOnlySpec,
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
     KVCacheConfig,
@@ -2165,3 +2166,97 @@ def test_hma_not_disabled_when_kv_events_enabled():
     assert vllm_config.scheduler_config.disable_hybrid_kv_cache_manager is False, (
         "kv_events_config must not force-disable the hybrid KV cache manager."
     )
+
+
+def new_cache_only_spec(
+    block_size=16,
+    num_kv_heads=4,
+    head_size=128,
+    dtype=torch.float32,
+):
+    return CacheOnlySpec(
+        block_size=block_size,
+        num_kv_heads=num_kv_heads,
+        head_size=head_size,
+        dtype=dtype,
+    )
+
+
+def test_get_kv_cache_groups_cache_only_stripped():
+    """CacheOnly layers should be stripped from groups (they are supplementary)."""
+    vllm_config = VllmConfig(model_config=ModelConfig(max_model_len=16))
+    kv_cache_spec = {
+        "layer_0": new_kv_cache_spec(),
+        "layer_1": new_kv_cache_spec(),
+        "cache_layer": new_cache_only_spec(),
+    }
+    groups = kv_cache_utils.get_kv_cache_groups(vllm_config, kv_cache_spec)
+    # CacheOnly should NOT appear in any group — only regular layers
+    assert len(groups) == 1
+    assert "layer_0" in groups[0].layer_names
+    assert "layer_1" in groups[0].layer_names
+    assert "cache_layer" not in groups[0].layer_names
+
+
+def test_split_supplementary_specs():
+    """split_supplementary_specs should separate CacheOnly from regular specs."""
+    kv_cache_spec = {
+        "layer_0": new_kv_cache_spec(),
+        "layer_1": new_sliding_window_spec(),
+        "cache_layer": new_cache_only_spec(),
+    }
+    regular, supplementary = kv_cache_utils.split_supplementary_specs(kv_cache_spec)
+    assert "layer_0" in regular
+    assert "layer_1" in regular
+    assert "cache_layer" not in regular
+    assert "cache_layer" in supplementary
+    assert isinstance(supplementary["cache_layer"], CacheOnlySpec)
+
+
+def test_get_kv_cache_groups_cache_only_excluded_from_unify():
+    """CacheOnly should not crash unify_hybrid_kv_cache_specs."""
+    vllm_config = VllmConfig(model_config=ModelConfig(max_model_len=16))
+    vllm_config.scheduler_config.disable_hybrid_kv_cache_manager = True
+    kv_cache_spec = {
+        "layer_0": new_kv_cache_spec(),
+        "layer_1": new_sliding_window_spec(),
+        "cache_layer": new_cache_only_spec(),
+    }
+    # Should not raise — CacheOnly is pre-filtered before unification
+    groups = kv_cache_utils.get_kv_cache_groups(vllm_config, kv_cache_spec)
+    # Only regular layers, unified into one group
+    assert len(groups) == 1
+    assert "cache_layer" not in groups[0].layer_names
+
+
+def test_get_kv_cache_config_from_groups_budget():
+    """Memory budget should account for supplementary CacheOnly bytes per block."""
+    vllm_config = VllmConfig(model_config=ModelConfig(max_model_len=16))
+
+    main_spec = new_kv_cache_spec()
+    cache_spec = new_cache_only_spec()
+
+    main_page = main_spec.page_size_bytes  # 16 * 2 * 64 * 4 * 2 = 16384
+    cache_page = cache_spec.page_size_bytes  # 16 * 4 * 128 * 4 = 32768
+
+    # 2 main layers in one group: group_size=2, total main = 2 * main_page
+    # 1 supplementary cache_only layer: cache_page
+    # bytes_per_block = 2 * main_page + cache_page
+    available = (2 * main_page + cache_page) * 10  # room for 10 blocks
+    groups = [
+        KVCacheGroupSpec(["layer_0", "layer_1"], main_spec),
+    ]
+    supplementary = {"cache_layer": cache_spec}
+    config = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config, groups, available, supplementary_specs=supplementary
+    )
+    assert config.num_blocks == 10
+    # 2 main tensors + 1 supplementary tensor
+    assert len(config.kv_cache_tensors) == 3
+    assert config.kv_cache_tensors[0].size == main_page * 10
+    assert config.kv_cache_tensors[1].size == main_page * 10
+    assert config.kv_cache_tensors[2].size == cache_page * 10
+    assert config.kv_cache_tensors[2].shared_by == ["cache_layer"]
+    # supplementary_specs should be set on the config
+    assert "cache_layer" in config.supplementary_specs
+    assert isinstance(config.supplementary_specs["cache_layer"], CacheOnlySpec)

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1289,18 +1289,32 @@ class VllmConfig:
         if self.scheduler_config.disable_hybrid_kv_cache_manager is None:
             # Default to disable HMA, but only if the user didn't express a preference.
             if self.kv_transfer_config is not None:
-                # NOTE(Kuntai): turn HMA off for connector unless specifically enabled.
-                need_disable_hybrid_kv_cache_manager = True
-                logger.warning(
-                    "Turning off hybrid kv cache manager because "
-                    "`--kv-transfer-config` is set. This will reduce the "
-                    "performance of vLLM on LLMs with sliding window attention "
-                    "or Mamba attention. If you are a developer of kv connector"
-                    ", please consider supporting hybrid kv cache manager for "
-                    "your connector by making sure your connector is a subclass"
-                    " of `SupportsHMA` defined in kv_connector/v1/base.py and"
-                    " use --no-disable-hybrid-kv-cache-manager to start vLLM."
+                # Only disable HMA if the connector does not support it.
+                from vllm.distributed.kv_transfer.kv_connector.factory import (
+                    KVConnectorFactory,
                 )
+                from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+                    supports_hma,
+                )
+
+                connector_cls = KVConnectorFactory.get_connector_class(
+                    self.kv_transfer_config
+                )
+                if not supports_hma(connector_cls):
+                    need_disable_hybrid_kv_cache_manager = True
+                    logger.warning(
+                        "Turning off hybrid kv cache manager because "
+                        "`--kv-transfer-config` is set and the connector %s "
+                        "does not support HMA. This will reduce the "
+                        "performance of vLLM on LLMs with sliding window "
+                        "attention or Mamba attention. If you are a developer "
+                        "of kv connector, please consider supporting hybrid "
+                        "kv cache manager for your connector by making sure "
+                        "your connector is a subclass of `SupportsHMA` "
+                        "defined in kv_connector/v1/base.py and use "
+                        "--no-disable-hybrid-kv-cache-manager to start vLLM.",
+                        connector_cls.__name__,
+                    )
             self.scheduler_config.disable_hybrid_kv_cache_manager = (
                 need_disable_hybrid_kv_cache_manager
             )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
@@ -12,6 +12,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
     KVConnectorRole,
+    SupportsHMA,
 )
 from vllm.logger import init_logger
 from vllm.v1.attention.backend import AttentionMetadata
@@ -99,7 +100,7 @@ class ExampleHiddenStatesConnectorMetadata(KVConnectorMetadata):
         )
 
 
-class ExampleHiddenStatesConnector(KVConnectorBase_V1):
+class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
     """
     Simple debug implementation of a HiddenStatesConnector.
 
@@ -206,9 +207,20 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1):
         assert isinstance(connector_metadata, ExampleHiddenStatesConnectorMetadata)
 
         os.makedirs(self._storage_path, exist_ok=True)
+
+        # Use the GPU slot_mapping from the attention metadata rather than
+        # recomputing from scheduler block IDs. On hybrid models, kernel
+        # block splitting makes the two diverge.
+        slot_mapping = attn_metadata.slot_mapping
+
+        offset = 0
         for request in connector_metadata.requests:
+            num_tokens = request.token_ids.shape[0]
+            req_slot_mapping = slot_mapping[offset : offset + num_tokens]
+            offset += num_tokens
+
             hidden_states = extract_from_kv_cache(
-                kv_layer, request.slot_mapping, request.token_ids.shape[0]
+                kv_layer, req_slot_mapping, num_tokens
             )
             tensors = {
                 "hidden_states": hidden_states.detach().cpu(),
@@ -330,6 +342,15 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1):
         _ = self._req_blocks.pop(req_id, None)
 
         return False, {"hidden_states_path": req_filename}
+
+    def request_finished_all_groups(
+        self,
+        request: "Request",
+        block_ids: tuple[list[int], ...],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        # CacheOnly layers are supplementary — they share block IDs with
+        # group 0, so block_ids[0] is always the right one.
+        return self.request_finished(request, block_ids[0])
 
     @classmethod
     def get_required_kvcache_layout(cls, vllm_config: "VllmConfig") -> str | None:

--- a/vllm/model_executor/models/extract_hidden_states.py
+++ b/vllm/model_executor/models/extract_hidden_states.py
@@ -34,8 +34,8 @@ from vllm.v1.attention.backend import (
 )
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
+    CacheOnlySpec,
     KVCacheSpec,
-    MLAAttentionSpec,
 )
 
 ########## Custom Ops ########
@@ -322,11 +322,14 @@ class CacheOnlyAttentionLayer(nn.Module, AttentionLayerBase):
         return self.attn_backend
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
-        # Note: we use MLAAttentionSpec here to because it will
-        # produce page sizes of (block_size * num_kv_heads * head_size * dtype_size)
-        # whereas FullAttentionSpec will add an additional factor of 2
-        return MLAAttentionSpec(
-            block_size=self.block_size,
+        # Use the current cache_config.block_size rather than the value
+        # captured at __init__ time.  For hybrid models (e.g. Qwen3.5)
+        # block_size is adjusted upward after model loading to match the
+        # Mamba page size.  The CacheOnly layer shares slot_mapping with
+        # group 0, so it must use the same block_size.
+        block_size = vllm_config.cache_config.block_size
+        return CacheOnlySpec(
+            block_size=block_size,
             num_kv_heads=self.num_heads,
             head_size=self.head_size,
             dtype=self.kv_cache_torch_dtype,

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -18,6 +18,7 @@ from vllm.utils.hashing import sha256_cbor, xxhash_cbor
 from vllm.utils.math_utils import cdiv
 from vllm.utils.mem_utils import format_gib
 from vllm.v1.kv_cache_interface import (
+    CacheOnlySpec,
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
     KVCacheConfig,
@@ -1082,6 +1083,7 @@ def get_kv_cache_config_from_groups(
     vllm_config: VllmConfig,
     kv_cache_groups: list[KVCacheGroupSpec],
     available_memory: int,
+    supplementary_specs: dict[str, KVCacheSpec] | None = None,
 ) -> KVCacheConfig:
     """
     Generate the KV cache configuration from the KV cache groups and spec
@@ -1094,6 +1096,11 @@ def get_kv_cache_config_from_groups(
     Returns:
         The generated KVCacheConfig
     """
+    supplementary_specs = supplementary_specs or {}
+    supplementary_bytes_per_block = sum(
+        spec.page_size_bytes for spec in supplementary_specs.values()
+    )
+
     if len(kv_cache_groups) == 0:
         # Attention free models do not have KV cache.
         # Return num_blocks=1 as BlockPool always needs a null_block.
@@ -1101,6 +1108,7 @@ def get_kv_cache_config_from_groups(
             num_blocks=1,
             kv_cache_tensors=[],
             kv_cache_groups=kv_cache_groups,
+            supplementary_specs=supplementary_specs,
         )
 
     # Determine how model runners should initialize the KV cache tensors.
@@ -1110,8 +1118,9 @@ def get_kv_cache_config_from_groups(
         # Special case: all layers have the same type of KV cache but with
         # different hidden size. Allocate different amount of memory for each
         # layer based on its hidden size.
-        num_blocks = (
-            available_memory // kv_cache_groups[0].kv_cache_spec.page_size_bytes
+        main_bytes = kv_cache_groups[0].kv_cache_spec.page_size_bytes
+        num_blocks = int(
+            available_memory // (main_bytes + supplementary_bytes_per_block)
         )
         num_blocks = may_override_num_blocks(vllm_config, num_blocks)
         per_layer_specs = kv_cache_groups[0].kv_cache_spec.kv_cache_specs
@@ -1137,9 +1146,11 @@ def get_kv_cache_config_from_groups(
             [group.kv_cache_spec for group in kv_cache_groups]
         )
         assert group_size > 0, "group_size must be greater than 0"
-        num_blocks = get_num_blocks(
-            vllm_config, group_size, available_memory, page_size
-        )
+        # Account for supplementary memory in the per-block budget.
+        total_per_block = page_size * group_size + supplementary_bytes_per_block
+        num_blocks = int(available_memory // total_per_block)
+        num_blocks = max(num_blocks, 0)
+        num_blocks = may_override_num_blocks(vllm_config, num_blocks)
         kv_cache_tensors = []
         for i in range(group_size):
             shared_by = []
@@ -1150,10 +1161,22 @@ def get_kv_cache_config_from_groups(
                 KVCacheTensor(size=page_size * num_blocks, shared_by=shared_by)
             )
 
+    # Append supplementary tensors (e.g. CacheOnly hidden-state storage).
+    # Each gets its own allocation with its own page_size, sharing the same
+    # num_blocks as the main groups.
+    for layer_name, spec in supplementary_specs.items():
+        kv_cache_tensors.append(
+            KVCacheTensor(
+                size=spec.page_size_bytes * num_blocks,
+                shared_by=[layer_name],
+            )
+        )
+
     return KVCacheConfig(
         num_blocks=num_blocks,
         kv_cache_tensors=kv_cache_tensors,
         kv_cache_groups=kv_cache_groups,
+        supplementary_specs=supplementary_specs,
     )
 
 
@@ -1225,6 +1248,10 @@ def get_kv_cache_groups(
     """
     Split the layers in the model into groups with the same KV cache spec.
 
+    CacheOnly specs (supplementary layers) are stripped before grouping and
+    returned separately via ``split_supplementary_specs``.  They do not
+    participate in the group/coordinator system.
+
     Args:
         vllm_config: The global VllmConfig
         kv_cache_spec: The kv cache spec of each attention layer in the model
@@ -1232,20 +1259,22 @@ def get_kv_cache_groups(
     Returns:
         The generated KVCacheGroups
     """
-    if vllm_config.scheduler_config.disable_hybrid_kv_cache_manager:
-        unify_hybrid_kv_cache_specs(kv_cache_spec)
+    regular, _ = split_supplementary_specs(kv_cache_spec)
 
-    if is_kv_cache_type_attention_free(kv_cache_spec):
+    if vllm_config.scheduler_config.disable_hybrid_kv_cache_manager:
+        unify_hybrid_kv_cache_specs(regular)
+
+    if is_kv_cache_type_attention_free(regular):
         # This returns an empty list to allow for the KVCacheManager to handle
         # attention free models.
         return []
 
-    if is_kv_cache_spec_uniform(kv_cache_spec):
+    if is_kv_cache_spec_uniform(regular):
         # KV cache of all layers are the same, which is true for
         # most models. Allocate the same amount of memory for
         # each layer.
-        return _get_kv_cache_groups_uniform_spec(kv_cache_spec)
-    elif uniform_spec := UniformTypeKVCacheSpecs.from_specs(kv_cache_spec):
+        return _get_kv_cache_groups_uniform_spec(regular)
+    elif uniform_spec := UniformTypeKVCacheSpecs.from_specs(regular):
         # All layers need the same number of token slots (e.g., all layers are
         # full attention, or all layers are sliding window attention with the
         # same window size). Put all layers into one group.
@@ -1254,12 +1283,29 @@ def get_kv_cache_groups(
     # As KVCacheManager can only allocate memory of one size, we need to unify
     # the page size of the layers. For cases cannot be unified, this function
     # will raise an error.
-    kv_cache_spec = unify_kv_cache_spec_page_size(kv_cache_spec)
+    regular = unify_kv_cache_spec_page_size(regular)
     # Model contains multiple attention types, but KV cache of all layers
     # have the same physical memory per block per layer. Split the layers
     # into groups with the same number of layers, and thus same total page
     # size.
-    return _get_kv_cache_groups_uniform_page_size(kv_cache_spec)
+    return _get_kv_cache_groups_uniform_page_size(regular)
+
+
+def split_supplementary_specs(
+    kv_cache_spec: dict[str, KVCacheSpec],
+) -> tuple[dict[str, KVCacheSpec], dict[str, KVCacheSpec]]:
+    """Separate CacheOnly (supplementary) specs from regular attention specs.
+
+    Returns:
+        (regular_specs, supplementary_specs)
+    """
+    supplementary: dict[str, KVCacheSpec] = {
+        k: v for k, v in kv_cache_spec.items() if isinstance(v, CacheOnlySpec)
+    }
+    regular: dict[str, KVCacheSpec] = {
+        k: v for k, v in kv_cache_spec.items() if not isinstance(v, CacheOnlySpec)
+    }
+    return regular, supplementary
 
 
 def generate_scheduler_kv_cache_config(
@@ -1332,9 +1378,11 @@ def _report_kv_cache_config(
 def _max_memory_usage_bytes_from_groups(
     vllm_config: VllmConfig,
     kv_cache_groups: list[KVCacheGroupSpec],
+    supplementary_specs: dict[str, KVCacheSpec] | None = None,
 ) -> int:
     """
-    Calculate maximum memory usage in bytes from KV cache groups.
+    Calculate maximum memory usage in bytes from KV cache groups and
+    supplementary specs.
 
     This correctly accounts for padding in hybrid models. For example, if a
     model has 8 full attention layers and 9 sliding window layers, they will
@@ -1348,29 +1396,38 @@ def _max_memory_usage_bytes_from_groups(
         kv_cache_groups[0].kv_cache_spec, UniformTypeKVCacheSpecs
     ):
         per_layer_specs = kv_cache_groups[0].kv_cache_spec.kv_cache_specs
-        return sum(
+        main_memory = sum(
             spec.max_memory_usage_bytes(vllm_config)
             for spec in per_layer_specs.values()
         )
+    else:
+        # General case: group_size pools, each shared by one layer per group
+        # Memory = group_size * page_size * blocks_for_max_len
+        group_size = max(len(group.layer_names) for group in kv_cache_groups)
+        page_size = get_uniform_page_size(
+            [group.kv_cache_spec for group in kv_cache_groups]
+        )
+        blocks_needed = sum(
+            cdiv(
+                group.kv_cache_spec.max_memory_usage_bytes(vllm_config),
+                page_size,
+            )
+            for group in kv_cache_groups
+        )
+        main_memory = group_size * page_size * blocks_needed
 
-    # General case: group_size pools, each shared by one layer per group
-    # Memory = group_size * page_size * blocks_for_max_len
-    group_size = max(len(group.layer_names) for group in kv_cache_groups)
-    page_size = get_uniform_page_size(
-        [group.kv_cache_spec for group in kv_cache_groups]
+    supp_memory = sum(
+        spec.max_memory_usage_bytes(vllm_config)
+        for spec in (supplementary_specs or {}).values()
     )
-    blocks_needed = sum(
-        cdiv(group.kv_cache_spec.max_memory_usage_bytes(vllm_config), page_size)
-        for group in kv_cache_groups
-    )
-
-    return group_size * page_size * blocks_needed
+    return main_memory + supp_memory
 
 
 def _estimate_max_model_len_from_groups(
     vllm_config: VllmConfig,
     kv_cache_groups: list[KVCacheGroupSpec],
     available_memory: int,
+    supplementary_specs: dict[str, KVCacheSpec] | None = None,
 ) -> int:
     """
     Binary search for the maximum model length that fits in available memory.
@@ -1381,7 +1438,9 @@ def _estimate_max_model_len_from_groups(
     def fits(model_len: int) -> bool:
         vllm_config.model_config.max_model_len = model_len
         return (
-            _max_memory_usage_bytes_from_groups(vllm_config, kv_cache_groups)
+            _max_memory_usage_bytes_from_groups(
+                vllm_config, kv_cache_groups, supplementary_specs
+            )
             <= available_memory
         )
 
@@ -1406,6 +1465,7 @@ def _auto_fit_max_model_len(
     vllm_config: VllmConfig,
     projected_groups_per_worker: list[list[KVCacheGroupSpec]],
     available_memory: list[int],
+    supplementary_specs_per_worker: list[dict[str, KVCacheSpec]] | None = None,
 ) -> None:
     """
     When max_model_len is set to -1, this function estimates the largest
@@ -1418,6 +1478,8 @@ def _auto_fit_max_model_len(
         projected_groups_per_worker: KV cache groups projected to each worker.
         available_memory: Memory available for KV cache in bytes for each
             worker.
+        supplementary_specs_per_worker: Supplementary specs per worker, used
+            to include supplementary memory in the budget.
     """
     original_max = vllm_config.model_config.max_model_len
 
@@ -1431,13 +1493,23 @@ def _auto_fit_max_model_len(
         )
         return
 
+    supp_per_worker: list[dict[str, KVCacheSpec] | None] = (
+        list(supplementary_specs_per_worker)
+        if supplementary_specs_per_worker
+        else [None] * len(projected_groups_per_worker)
+    )
+
     # Find the max_model_len that fits across all workers.
     auto_fit_max = original_max
     limiting_worker_mem = available_memory[0]
-    for groups, avail_mem in zip(projected_groups_per_worker, available_memory):
+    for groups, avail_mem, supp in zip(
+        projected_groups_per_worker, available_memory, supp_per_worker
+    ):
         if not groups:
             continue
-        worker_max = _estimate_max_model_len_from_groups(vllm_config, groups, avail_mem)
+        worker_max = _estimate_max_model_len_from_groups(
+            vllm_config, groups, avail_mem, supplementary_specs=supp
+        )
         if worker_max < auto_fit_max:
             auto_fit_max = worker_max
             limiting_worker_mem = avail_mem
@@ -1554,6 +1626,9 @@ def get_kv_cache_configs(
                     "across workers. This is not supported yet."
                 )
 
+    # Split supplementary specs (e.g. CacheOnly) from regular specs.
+    _, global_supplementary = split_supplementary_specs(merged_kv_cache_specs)
+
     # Get global KV cache groups. This also handles spec unification for
     # hybrid models when disable_hybrid_kv_cache_manager is enabled.
     # After this call, merged_kv_cache_specs may be modified in-place.
@@ -1567,32 +1642,64 @@ def get_kv_cache_configs(
         for worker_spec in kv_cache_specs
     ]
 
+    # Project supplementary specs to each worker (only include layers
+    # present on that worker).
+    def _project_supplementary(
+        worker_spec: dict[str, KVCacheSpec],
+    ) -> dict[str, KVCacheSpec]:
+        return {k: v for k, v in global_supplementary.items() if k in worker_spec}
+
+    supplementary_per_worker = [_project_supplementary(ws) for ws in kv_cache_specs]
+
     if vllm_config.model_config.original_max_model_len == -1:
         _auto_fit_max_model_len(
-            vllm_config, projected_groups_per_worker, available_memory
+            vllm_config,
+            projected_groups_per_worker,
+            available_memory,
+            supplementary_specs_per_worker=supplementary_per_worker,
         )
 
     # Check if the available memory is enough per worker.
-    for groups, avail_mem in zip(projected_groups_per_worker, available_memory):
+    for groups, avail_mem, supp in zip(
+        projected_groups_per_worker, available_memory, supplementary_per_worker
+    ):
         if not groups:
             continue
         _check_enough_kv_cache_memory(
             avail_mem,
-            partial(_max_memory_usage_bytes_from_groups, vllm_config, groups),
+            partial(_max_memory_usage_bytes_from_groups, vllm_config, groups, supp),
             vllm_config.model_config.max_model_len,
-            partial(_estimate_max_model_len_from_groups, vllm_config, groups),
+            partial(
+                _estimate_max_model_len_from_groups,
+                vllm_config,
+                groups,
+                supplementary_specs=supp,
+            ),
         )
 
     kv_cache_configs: list[KVCacheConfig] = []
-    for projected_groups, kv_cache_spec_one_worker, available_memory_one_worker in zip(
-        projected_groups_per_worker, kv_cache_specs, available_memory
+    for (
+        projected_groups,
+        kv_cache_spec_one_worker,
+        available_memory_one_worker,
+        worker_supplementary,
+    ) in zip(
+        projected_groups_per_worker,
+        kv_cache_specs,
+        available_memory,
+        supplementary_per_worker,
     ):
-        assert sum(len(group.layer_names) for group in projected_groups) == len(
-            kv_cache_spec_one_worker
-        ), "Some layers are not assigned to any group."
+        assert sum(len(group.layer_names) for group in projected_groups) + len(
+            worker_supplementary
+        ) == len(kv_cache_spec_one_worker), (
+            "Some layers are not assigned to any group or supplementary."
+        )
         kv_cache_configs.append(
             get_kv_cache_config_from_groups(
-                vllm_config, projected_groups, available_memory_one_worker
+                vllm_config,
+                projected_groups,
+                available_memory_one_worker,
+                supplementary_specs=worker_supplementary,
             )
         )
 

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import copy
-from dataclasses import dataclass, fields, replace
+from dataclasses import dataclass, field, fields, replace
 from enum import IntEnum
 from math import prod
 from typing import TYPE_CHECKING
@@ -310,6 +310,21 @@ class MLAAttentionSpec(FullAttentionSpec):
         )
 
 
+@dataclass(frozen=True)
+class CacheOnlySpec(MLAAttentionSpec):
+    """KV cache spec for hidden-state-only storage (no attention computation).
+
+    Inherits from MLAAttentionSpec so that gpu_model_runner.py handles it
+    via existing AttentionSpec code paths (reshape, bind, etc.).
+
+    CacheOnly layers are treated as *supplementary tensors*: they share block
+    IDs with the primary attention group (group 0) and are invisible to the
+    KV cache coordinator.  They are never placed into a KVCacheGroupSpec.
+    """
+
+    pass
+
+
 @dataclass(frozen=True, kw_only=True)
 class ChunkedLocalAttentionSpec(AttentionSpec):
     attention_chunk_size: int
@@ -574,6 +589,13 @@ class KVCacheConfig:
     contains all layers.
     For models with multiple types of attention, there will be multiple groups,
     see `_get_kv_cache_config_uniform_page_size` for more details.
+    """
+    supplementary_specs: dict[str, KVCacheSpec] = field(default_factory=dict)
+    """
+    Layers that piggyback on the block pool but do not participate in block
+    management (e.g. CacheOnly layers for hidden-state extraction).  They
+    share block IDs with the primary attention group and are invisible to
+    the KV cache coordinator.
     """
 
     @property

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -114,6 +114,18 @@ def init_attn_backend(
                 min_cg_attn_backend = attn_backend.__name__
         attn_groups.append(groups)
 
+    # Include supplementary layers (e.g. CacheOnly) in attn_backends so
+    # their tensors can be reshaped and bound.
+    supp_layer_names = list(kv_cache_config.supplementary_specs.keys())
+    if supp_layer_names:
+        layer_type = cast(type[Any], AttentionLayerBase)
+        supp_layers = get_layers_from_vllm_config(
+            vllm_config, layer_type, supp_layer_names
+        )
+        for layer_name in supp_layer_names:
+            if layer_name in supp_layers:
+                attn_backends[layer_name] = supp_layers[layer_name].get_attn_backend()
+
     return (
         attn_backends,
         attn_groups,
@@ -135,10 +147,49 @@ def _allocate_kv_cache(kv_cache_config: KVCacheConfig, device: torch.device):
     for group in kv_cache_config.kv_cache_groups:
         for layer_name in group.layer_names:
             layer_names.add(layer_name)
+    # Supplementary layers (e.g. CacheOnly) also have tensors but no group.
+    layer_names.update(kv_cache_config.supplementary_specs.keys())
     assert layer_names == set(kv_cache_raw_tensors.keys()), (
         "Some layers are not correctly initialized"
     )
     return kv_cache_raw_tensors
+
+
+def _reshape_one_layer(
+    layer_name: str,
+    kv_cache_spec: AttentionSpec,
+    raw_tensor: torch.Tensor,
+    attn_backend: type[AttentionBackend],
+    cache_dtype: str,
+) -> torch.Tensor:
+    """Reshape a raw byte tensor into the backend-specific KV cache shape."""
+    assert raw_tensor.numel() % kv_cache_spec.page_size_bytes == 0
+    num_blocks = raw_tensor.numel() // kv_cache_spec.page_size_bytes
+
+    kv_cache_shape = attn_backend.get_kv_cache_shape(
+        num_blocks,
+        kv_cache_spec.block_size,
+        kv_cache_spec.num_kv_heads,
+        kv_cache_spec.head_size,
+        cache_dtype,
+    )
+
+    # FIXME(woosuk): Add kv_cache_stride_order to all attention backends.
+    try:
+        kv_cache_stride_order = attn_backend.get_kv_cache_stride_order()
+        assert len(kv_cache_stride_order) == len(kv_cache_shape)
+    except (AttributeError, NotImplementedError):
+        kv_cache_stride_order = tuple(range(len(kv_cache_shape)))
+
+    kv_cache_shape = tuple(kv_cache_shape[i] for i in kv_cache_stride_order)
+    inv_order = [
+        kv_cache_stride_order.index(i) for i in range(len(kv_cache_stride_order))
+    ]
+
+    dtype = kv_cache_spec.dtype
+    viewed = raw_tensor.view(dtype)
+    viewed = viewed.view(kv_cache_shape)
+    return viewed.permute(*inv_order)
 
 
 def _reshape_kv_cache(
@@ -148,43 +199,33 @@ def _reshape_kv_cache(
     cache_dtype: str,
 ) -> dict[str, torch.Tensor]:
     kv_caches: dict[str, torch.Tensor] = {}
+
+    # Reshape group layers.
     for kv_cache_group_spec in kv_cache_config.kv_cache_groups:
         for layer_name in kv_cache_group_spec.layer_names:
             kv_cache_spec = kv_cache_group_spec.kv_cache_spec
             if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
                 kv_cache_spec = kv_cache_spec.kv_cache_specs[layer_name]
             assert isinstance(kv_cache_spec, AttentionSpec)
-
-            raw_tensor = kv_cache_raw_tensors[layer_name]
-            assert raw_tensor.numel() % kv_cache_spec.page_size_bytes == 0
-            num_blocks = raw_tensor.numel() // kv_cache_spec.page_size_bytes
-
-            attn_backend = attn_backends[layer_name]
-            kv_cache_shape = attn_backend.get_kv_cache_shape(
-                num_blocks,
-                kv_cache_spec.block_size,
-                kv_cache_spec.num_kv_heads,
-                kv_cache_spec.head_size,
+            kv_caches[layer_name] = _reshape_one_layer(
+                layer_name,
+                kv_cache_spec,
+                kv_cache_raw_tensors[layer_name],
+                attn_backends[layer_name],
                 cache_dtype,
             )
 
-            # FIXME(woosuk): Add kv_cache_stride_order to all attention backends.
-            try:
-                kv_cache_stride_order = attn_backend.get_kv_cache_stride_order()
-                assert len(kv_cache_stride_order) == len(kv_cache_shape)
-            except (AttributeError, NotImplementedError):
-                kv_cache_stride_order = tuple(range(len(kv_cache_shape)))
+    # Reshape supplementary layers (e.g. CacheOnly).
+    for layer_name, spec in kv_cache_config.supplementary_specs.items():
+        assert isinstance(spec, AttentionSpec)
+        kv_caches[layer_name] = _reshape_one_layer(
+            layer_name,
+            spec,
+            kv_cache_raw_tensors[layer_name],
+            attn_backends[layer_name],
+            cache_dtype,
+        )
 
-            kv_cache_shape = tuple(kv_cache_shape[i] for i in kv_cache_stride_order)
-            inv_order = [
-                kv_cache_stride_order.index(i)
-                for i in range(len(kv_cache_stride_order))
-            ]
-
-            dtype = kv_cache_spec.dtype
-            raw_tensor = raw_tensor.view(dtype)
-            raw_tensor = raw_tensor.view(kv_cache_shape)
-            kv_caches[layer_name] = raw_tensor.permute(*inv_order)
     return kv_caches
 
 
@@ -212,6 +253,14 @@ def build_slot_mappings_by_layer(
     for slot_mapping, kv_cache_group in zip(slot_mappings, kv_cache_groups):
         for layer_name in kv_cache_group.layer_names:
             slot_mappings_by_layer[layer_name] = slot_mapping
+
+    # Supplementary layers (e.g. CacheOnly) share group 0's block table,
+    # so they use group 0's slot_mapping.
+    if kv_cache_config.supplementary_specs:
+        group0_slot_mapping = slot_mappings[0]
+        for layer_name in kv_cache_config.supplementary_specs:
+            slot_mappings_by_layer[layer_name] = group0_slot_mapping
+
     return slot_mappings_by_layer
 
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -188,6 +188,7 @@ from vllm.v1.worker.cp_utils import (
 )
 from vllm.v1.worker.dp_utils import coordinate_batch_across_dp
 from vllm.v1.worker.ec_connector_model_runner_mixin import ECConnectorModelRunnerMixin
+from vllm.v1.worker.gpu.attn_utils import _reshape_one_layer
 from vllm.v1.worker.gpu.pool.late_interaction_runner import LateInteractionRunner
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm.v1.worker.gpu_ubatch_wrapper import UBatchWrapper
@@ -3747,6 +3748,13 @@ class GPUModelRunner(
             for layer_name in kv_cache_group.layer_names:
                 slot_mappings_by_layer[layer_name] = slot_mapping
 
+        # Supplementary layers (e.g. CacheOnly) share group 0's block table,
+        # so they use group 0's slot_mapping.
+        if self.kv_cache_config.supplementary_specs:
+            group0_slot_mapping = slot_mappings_by_gid[0]
+            for layer_name in self.kv_cache_config.supplementary_specs:
+                slot_mappings_by_layer[layer_name] = group0_slot_mapping
+
         if ubatch_slices is not None:
             result: list[dict[str, torch.Tensor]] = []
             for ubatch in ubatch_slices:
@@ -5817,9 +5825,11 @@ class GPUModelRunner(
         from vllm.v1.core.kv_cache_utils import (
             get_kv_cache_config_from_groups,
             get_kv_cache_groups,
+            split_supplementary_specs,
         )
 
         kv_cache_spec = self.get_kv_cache_spec()
+        _, supplementary_specs = split_supplementary_specs(kv_cache_spec)
         kv_cache_groups = get_kv_cache_groups(self.vllm_config, kv_cache_spec)
         min_blocks = self.compilation_config.max_cudagraph_capture_size or 1
 
@@ -5827,7 +5837,10 @@ class GPUModelRunner(
         saved_override = self.cache_config.num_gpu_blocks_override
         self.cache_config.num_gpu_blocks_override = min_blocks
         minimal_config = get_kv_cache_config_from_groups(
-            self.vllm_config, kv_cache_groups, available_memory=0
+            self.vllm_config,
+            kv_cache_groups,
+            available_memory=0,
+            supplementary_specs=supplementary_specs,
         )
         self.cache_config.num_gpu_blocks_override = saved_override
 
@@ -6486,6 +6499,8 @@ class GPUModelRunner(
                 if layer_name in self.runner_only_attn_layers:
                     continue
                 layer_names.add(layer_name)
+        # Supplementary layers (e.g. CacheOnly) also have tensors but no group.
+        layer_names.update(kv_cache_config.supplementary_specs.keys())
         assert layer_names == set(kv_cache_raw_tensors.keys()), (
             "Some layers are not correctly initialized"
         )
@@ -6598,6 +6613,26 @@ class GPUModelRunner(
                     kv_caches[layer_name] = state_tensors
                 else:
                     raise NotImplementedError
+
+        # Reshape supplementary layers (e.g. CacheOnly for hidden-state
+        # extraction).  They are not part of any attn_group but still need
+        # their raw tensors reshaped and included in kv_caches.
+        for layer_name, spec in kv_cache_config.supplementary_specs.items():
+            assert isinstance(spec, AttentionSpec)
+
+            layer_type = cast(type[Any], AttentionLayerBase)
+            supp_layers = get_layers_from_vllm_config(
+                self.vllm_config, layer_type, [layer_name]
+            )
+            attn_backend = supp_layers[layer_name].get_attn_backend()
+
+            kv_caches[layer_name] = _reshape_one_layer(
+                layer_name,
+                spec,
+                kv_cache_raw_tensors[layer_name],
+                attn_backend,
+                self.cache_config.cache_dtype,
+            )
 
         if has_attn and has_mamba:
             self._update_hybrid_attention_mamba_layout(kv_caches, kernel_block_sizes)


### PR DESCRIPTION
## Summary

- Adds hybrid model support (e.g. Qwen3.5) for `extract_hidden_states` speculative decoding by modeling CacheOnly as supplementary tensors that share group 0's block table
- Introduces `supplementary_specs` field on `KVCacheConfig` — CacheOnly layers get their own KV cache tensors but are invisible to the KV cache coordinator
- Shared `_reshape_one_layer()` helper in `attn_utils.py` eliminates reshape duplication
- Uses GPU-authoritative `attn_metadata.slot_mapping` instead of scheduler-computed slot mappings
- Gates HMA disable with `supports_hma()` check so hybrid models keep per-group block allocators

**This is 1 of 3 alternative approaches** — see [RFC document](https://github.com/neuralmagic/vllm/blob/hma/extract-hidden-states-supplementary/local/explanation/hybrid_hidden_states_rfc.md) and sister PRs for comparison:
- **Approach A:** CacheOnly as filtered KV cache group — neuralmagic/vllm#160
- **Approach B (this PR):** CacheOnly as supplementary tensors (8 files, +433/-87)
- **Approach C:** Bypass KV cache entirely — #TBD

## Test plan

- [ ] Verified on Qwen3.5-9B with TP=4, non-zero hidden states extracted
- [ ] Verified on standard (non-hybrid) model — no regression
- [ ] `pre-commit run --all-files` passes on changed files
- [ ] Unit tests added in `tests/v1/core/test_kv_cache_utils.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)