### PR TITLE
[RFC] Hybrid model ExtractHiddenStates: bypass KV cache

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1289,18 +1289,32 @@ class VllmConfig:
         if self.scheduler_config.disable_hybrid_kv_cache_manager is None:
             # Default to disable HMA, but only if the user didn't express a preference.
             if self.kv_transfer_config is not None:
-                # NOTE(Kuntai): turn HMA off for connector unless specifically enabled.
-                need_disable_hybrid_kv_cache_manager = True
-                logger.warning(
-                    "Turning off hybrid kv cache manager because "
-                    "`--kv-transfer-config` is set. This will reduce the "
-                    "performance of vLLM on LLMs with sliding window attention "
-                    "or Mamba attention. If you are a developer of kv connector"
-                    ", please consider supporting hybrid kv cache manager for "
-                    "your connector by making sure your connector is a subclass"
-                    " of `SupportsHMA` defined in kv_connector/v1/base.py and"
-                    " use --no-disable-hybrid-kv-cache-manager to start vLLM."
+                # Only disable HMA if the connector does not support it.
+                from vllm.distributed.kv_transfer.kv_connector.factory import (
+                    KVConnectorFactory,
                 )
+                from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+                    supports_hma,
+                )
+
+                connector_cls = KVConnectorFactory.get_connector_class(
+                    self.kv_transfer_config
+                )
+                if not supports_hma(connector_cls):
+                    need_disable_hybrid_kv_cache_manager = True
+                    logger.warning(
+                        "Turning off hybrid kv cache manager because "
+                        "`--kv-transfer-config` is set and the connector %s "
+                        "does not support HMA. This will reduce the "
+                        "performance of vLLM on LLMs with sliding window "
+                        "attention or Mamba attention. If you are a developer "
+                        "of kv connector, please consider supporting hybrid "
+                        "kv cache manager for your connector by making sure "
+                        "your connector is a subclass of `SupportsHMA` "
+                        "defined in kv_connector/v1/base.py and use "
+                        "--no-disable-hybrid-kv-cache-manager to start vLLM.",
+                        connector_cls.__name__,
+                    )
             self.scheduler_config.disable_hybrid_kv_cache_manager = (
                 need_disable_hybrid_kv_cache_manager
             )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
@@ -7,11 +7,12 @@ from typing import TYPE_CHECKING, Any, Optional
 import safetensors
 import torch
 
-from vllm.config import VllmConfig, get_layers_from_vllm_config
+from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
     KVConnectorRole,
+    SupportsHMA,
 )
 from vllm.logger import init_logger
 from vllm.v1.attention.backend import AttentionMetadata
@@ -25,58 +26,14 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
-def extract_from_kv_cache(
-    kv_cache: torch.Tensor,
-    slot_mapping: torch.Tensor,
-    num_tokens: int,
-) -> torch.Tensor:
-    """Extract data from KV cache
-    Assume the shape of the kv_cache is (num_pages, page_size, num_heads, head_size)
-    """
-
-    padded_kv = kv_cache.flatten(0, 1)[slot_mapping]
-    # shape: [len(slot_mapping), num_heads, head_size]
-    return padded_kv[:num_tokens]  # shape: [num_tokens, num_heads, head_size]
-
-
 @dataclass
 class ReqMeta:
-    # Request ID
-    req_id: str
-    # Request filename
-    filename: str
-    # Request tokens
-    token_ids: torch.Tensor
-    # Slot mappings, should have the same length as token_ids
-    slot_mapping: torch.Tensor
-    # Whether this request is a new request or partially computed already
-    new_req: bool
+    """Lightweight per-request metadata for hidden-state accumulation."""
 
-    @staticmethod
-    def make_meta(
-        req_id: str,
-        filename: str,
-        token_ids: list[int],
-        block_ids: list[int],
-        block_size: int,
-        new_req: bool,
-    ) -> "ReqMeta":
-        token_ids_tensor = torch.tensor(token_ids)
-        block_ids_tensor = torch.tensor(block_ids)
-        num_blocks = block_ids_tensor.shape[0]
-        block_offsets = torch.arange(0, block_size)
-        slot_mapping = (
-            block_offsets.reshape((1, block_size))
-            + block_ids_tensor.reshape((num_blocks, 1)) * block_size
-        )
-        slot_mapping = slot_mapping.flatten()
-        return ReqMeta(
-            req_id=req_id,
-            filename=filename,
-            token_ids=token_ids_tensor,
-            slot_mapping=slot_mapping,
-            new_req=new_req,
-        )
+    req_id: str
+    filename: str
+    token_ids: list[int]
+    new_req: bool
 
 
 @dataclass
@@ -88,32 +45,30 @@ class ExampleHiddenStatesConnectorMetadata(KVConnectorMetadata):
         req_id: str,
         filename: str,
         token_ids: list[int],
-        block_ids: list[int],
-        block_size: int,
         new_req: bool = True,
     ) -> None:
         self.requests.append(
-            ReqMeta.make_meta(
-                req_id, filename, token_ids, block_ids, block_size, new_req
+            ReqMeta(
+                req_id=req_id,
+                filename=filename,
+                token_ids=token_ids,
+                new_req=new_req,
             )
         )
 
 
-class ExampleHiddenStatesConnector(KVConnectorBase_V1):
-    """
-    Simple debug implementation of a HiddenStatesConnector.
+class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
+    """Hidden-states connector that bypasses the KV cache.
 
-    Simply extracts the hidden states from the kv cache and stores them to disk.
-    Must be used in conjunction with the `extract_hidden_states` spec decoding method.
+    The proposer stacks target-model hidden states and calls
+    ``save_hidden_states()`` directly.  This connector accumulates the
+    per-request tensors on CPU and writes them to disk when the request
+    finishes.  No CacheOnly attention layers or KV cache groups are
+    required, so hybrid models work without any core KV-cache changes.
     """
 
     @property
     def prefer_cross_layer_blocks(self) -> bool:
-        """
-        Indicates whether this connector prefers KV blocks that hold KV data for all
-        layers, which can speed up KV data transfers. Defaults to False.
-        """
-        # Must be False so that drafter kv cache isn't merged with verifier's
         return False
 
     def __init__(
@@ -127,11 +82,9 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1):
             role=role,
             kv_cache_config=kv_cache_config,
         )
-        self._block_size = vllm_config.cache_config.block_size
         self._storage_path = self._kv_transfer_config.get_from_extra_config(
             "shared_storage_path", "/tmp"
         )
-        self.cache_layers: list[str] = []  # set by self.register_kv_caches
         logger.info(self._kv_transfer_config)
         logger.info("Shared storage path is %s", self._storage_path)
 
@@ -139,40 +92,27 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1):
             "ExampleHiddenStatesConnector only works when using "
             "'extract_hidden_states' speculative method"
         )
-        spec_config = self._vllm_config.speculative_config.draft_model_config.hf_config
-        self.num_hidden_states = len(
-            getattr(spec_config, "eagle_aux_hidden_state_layer_ids", [])
-        )
 
+        # Per-request accumulation buffers (CPU tensors).
+        self._accumulated_hs: dict[str, list[torch.Tensor]] = {}
+        self._accumulated_tokens: dict[str, list[int]] = {}
         self._request_filenames: dict[str, str] = {}
         self._active_requests: dict[str, NewRequestData] = {}
-        self._req_blocks: dict[str, list[int]] = {}
 
     # ==============================
     # Worker-side methods
     # ==============================
     def start_load_kv(self, *args, **kwargs: Any) -> None:
-        pass  # Empty implementation of abstract method
+        pass
 
     def wait_for_layer_load(self, layer_name: str) -> None:
-        pass  # Empty implementation of abstract method
+        pass
 
     def wait_for_save(self):
-        pass  # Empty implementation of abstract method
+        pass
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
-        from vllm.model_executor.models.extract_hidden_states import (
-            CacheOnlyAttentionLayer,
-        )
-
-        # Filter layers to only include CacheOnlyAttentionLayers
-        layers = get_layers_from_vllm_config(
-            self._vllm_config, CacheOnlyAttentionLayer, list(kv_caches.keys())
-        )
-        self.cache_layers = list(layers.keys())
-        assert len(self.cache_layers) == 1, (
-            f"Expected 1 CacheOnlyAttentionLayer, got {len(self.cache_layers)}"
-        )
+        pass  # No CacheOnly layers in bypass mode.
 
     def save_kv_layer(
         self,
@@ -181,87 +121,62 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1):
         attn_metadata: AttentionMetadata,
         **kwargs: Any,
     ) -> None:
-        """Start saving the KV cache of the layer from vLLM's paged buffer
-        to the connector.
+        pass  # Not used — hidden states arrive via save_hidden_states().
+
+    def save_hidden_states(
+        self,
+        hidden_states: torch.Tensor,
+        tokens_per_req: list[int],
+    ) -> None:
+        """Receive stacked hidden states from the proposer and accumulate.
 
         Args:
-            layer_name (str): the name of the layer.
-            kv_layer (torch.Tensor): the paged KV buffer of the current
-                layer in vLLM.
-            attn_metadata (AttentionMetadata): the attention metadata.
-            **kwargs: additional arguments for the save operation.
+            hidden_states: [total_tokens, num_hidden_states, hidden_size]
+                on the GPU.
+            tokens_per_req: Number of tokens for each request in the batch
+                (same order as connector metadata requests).
         """
-        if layer_name not in self.cache_layers:
-            return
-
-        from vllm.model_executor.models.extract_hidden_states import (
-            CacheOnlyAttentionMetadata,
-        )
-
-        assert isinstance(attn_metadata, CacheOnlyAttentionMetadata), (
-            "ExampleHiddenStatesConnector only supports CacheOnlyAttentionBackend"
-        )
-
         connector_metadata = self._get_connector_metadata()
         assert isinstance(connector_metadata, ExampleHiddenStatesConnectorMetadata)
 
-        os.makedirs(self._storage_path, exist_ok=True)
-        for request in connector_metadata.requests:
-            hidden_states = extract_from_kv_cache(
-                kv_layer, request.slot_mapping, request.token_ids.shape[0]
-            )
-            tensors = {
-                "hidden_states": hidden_states.detach().cpu(),
-                "token_ids": request.token_ids.detach().cpu(),
-            }
-            safetensors.torch.save_file(tensors, request.filename)
+        offset = 0
+        for i, request in enumerate(connector_metadata.requests):
+            if i >= len(tokens_per_req):
+                break
+            num_tokens = tokens_per_req[i]
+            hs = hidden_states[offset : offset + num_tokens].detach().cpu()
+            offset += num_tokens
+
+            req_id = request.req_id
+            if req_id not in self._accumulated_hs:
+                self._accumulated_hs[req_id] = []
+            self._accumulated_hs[req_id].append(hs)
+            self._accumulated_tokens[req_id] = request.token_ids
 
     # ==============================
     # Scheduler-side methods
     # ==============================
-
     def get_num_new_matched_tokens(
         self,
         request: "Request",
         num_computed_tokens: int,
     ) -> tuple[int | None, bool]:
-        """
-        Get number of new tokens that can be loaded from the
-        external KV cache beyond the num_computed_tokens.
-
-        Args:
-            request (Request): the request object.
-            num_computed_tokens (int): the number of locally
-                computed tokens for this request
-
-        Returns:
-            the number of tokens that can be loaded from the
-            external KV cache beyond what is already computed.
-        """
-        # This connector is store-only, so we don't need to load any tokens
         return 0, False
 
     def update_state_after_alloc(
-        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+        self,
+        request: "Request",
+        blocks: "KVCacheBlocks",
+        num_external_tokens: int,
     ):
-        # Usually used to handle allocation of new blocks for requests that are loading
-        # tokens from connector's external kv cache. We never load from external cache
-        # so this is a no-op.
         assert num_external_tokens == 0, "This connector is store-only"
 
     def build_connector_meta(
         self,
         scheduler_output: SchedulerOutput,
     ) -> KVConnectorMetadata:
-        """Build the connector metadata for this step.
-
-        This function should NOT modify any fields in the scheduler_output.
-        Also, calling this function will reset the state of the connector.
-
-        Args:
-            scheduler_output (SchedulerOutput): the scheduler output object.
-        """
         meta = ExampleHiddenStatesConnectorMetadata()
+
         for new_req in scheduler_output.scheduled_new_reqs:
             token_ids = new_req.prompt_token_ids or []
             filename = os.path.join(self._storage_path, f"{new_req.req_id}.safetensors")
@@ -269,37 +184,22 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1):
                 new_req.req_id,
                 filename=filename,
                 token_ids=token_ids,
-                block_ids=new_req.block_ids[0],
-                block_size=self._block_size,
             )
             self._request_filenames[new_req.req_id] = filename
             self._active_requests[new_req.req_id] = new_req
-            self._req_blocks[new_req.req_id] = list(new_req.block_ids[0])
 
+        # Include cached (continuing) requests so the worker-side
+        # save_hidden_states can match metadata entries to batch order.
         cached_reqs = scheduler_output.scheduled_cached_reqs
         for i, req_id in enumerate(cached_reqs.req_ids):
             if req_id not in self._active_requests:
                 continue
-
-            new_block_ids = cached_reqs.new_block_ids[i]
-
             cached_req = self._active_requests[req_id]
-            req_block_ids = self._req_blocks[req_id]
-
-            if new_block_ids is None:
-                continue
-
-            block_ids = new_block_ids[0]
-
-            req_block_ids.extend(block_ids)
             filename = os.path.join(self._storage_path, f"{req_id}.safetensors")
-
             meta.add_request(
                 req_id=req_id,
                 filename=filename,
                 token_ids=cached_req.prompt_token_ids or [],
-                block_ids=req_block_ids,
-                block_size=self._block_size,
                 new_req=False,
             )
 
@@ -310,47 +210,35 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1):
         request: "Request",
         block_ids: list[int],
     ) -> tuple[bool, dict[str, Any] | None]:
-        """
-        Called exactly once when a request has finished, before its blocks are
-        freed.
-
-        The connector may assumes responsibility for freeing the blocks
-        asynchronously by returning True.
-
-        Returns:
-            True if the request is being saved/sent asynchronously and blocks
-            should not be freed until the request_id is returned from
-            get_finished().
-            Optional KVTransferParams to be included in the request outputs
-            returned by the engine.
-        """
         req_id = request.request_id
-        req_filename = self._request_filenames.pop(req_id, None)
+        filename = self._request_filenames.pop(req_id, None)
         _ = self._active_requests.pop(req_id, None)
-        _ = self._req_blocks.pop(req_id, None)
 
-        return False, {"hidden_states_path": req_filename}
+        if req_id in self._accumulated_hs and filename:
+            os.makedirs(self._storage_path, exist_ok=True)
+            hs = torch.cat(self._accumulated_hs.pop(req_id), dim=0)
+            token_ids_list = self._accumulated_tokens.pop(req_id, [])
+            tensors = {
+                "hidden_states": hs,
+                "token_ids": torch.tensor(token_ids_list),
+            }
+            safetensors.torch.save_file(tensors, filename)
+
+        return False, {"hidden_states_path": filename}
+
+    def request_finished_all_groups(
+        self,
+        request: "Request",
+        block_ids: tuple[list[int], ...],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        flat = block_ids[0] if block_ids else []
+        return self.request_finished(request, flat)
 
     @classmethod
     def get_required_kvcache_layout(cls, vllm_config: "VllmConfig") -> str | None:
-        """
-        Get the required KV cache layout for this connector.
-        Args:
-            vllm_config (VllmConfig): the vllm config.
-
-        Returns:
-            str: the required KV cache layout. e.g. HND, or NHD.
-            None if the connector does not require a specific layout.
-        """
-
         if cls is KVConnectorBase_V1:
             raise TypeError(
                 "get_required_kvcache_layout should not be called "
                 "on the abstract base class"
             )
-        # NHD means we have (num_tokens, num_heads)
-        # HND means we have (num_heads, num_tokens)
-        # For now, we only support NHD layout since this keeps the
-        # hidden states for each token together in memory.
-        # HND is primarily used when sharding heads across devices.
         return "NHD"

--- a/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
@@ -128,7 +128,13 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
         hidden_states: torch.Tensor,
         tokens_per_req: list[int],
     ) -> None:
-        """Receive stacked hidden states from the proposer and accumulate.
+        """Receive stacked hidden states from the proposer, accumulate, and
+        persist to disk.
+
+        Because ``request_finished()`` runs on the *scheduler* process (which
+        has a separate connector instance), we must write the file here on the
+        worker side.  Each call overwrites the previous file for a given
+        request so that the latest accumulated state is always on disk.
 
         Args:
             hidden_states: [total_tokens, num_hidden_states, hidden_size]
@@ -138,6 +144,8 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
         """
         connector_metadata = self._get_connector_metadata()
         assert isinstance(connector_metadata, ExampleHiddenStatesConnectorMetadata)
+
+        os.makedirs(self._storage_path, exist_ok=True)
 
         offset = 0
         for i, request in enumerate(connector_metadata.requests):
@@ -152,6 +160,15 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
                 self._accumulated_hs[req_id] = []
             self._accumulated_hs[req_id].append(hs)
             self._accumulated_tokens[req_id] = request.token_ids
+
+            # Write the full accumulated hidden states to disk so the file
+            # is ready when the scheduler calls request_finished().
+            full_hs = torch.cat(self._accumulated_hs[req_id], dim=0)
+            tensors = {
+                "hidden_states": full_hs,
+                "token_ids": torch.tensor(request.token_ids),
+            }
+            safetensors.torch.save_file(tensors, request.filename)
 
     # ==============================
     # Scheduler-side methods
@@ -213,17 +230,7 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
         req_id = request.request_id
         filename = self._request_filenames.pop(req_id, None)
         _ = self._active_requests.pop(req_id, None)
-
-        if req_id in self._accumulated_hs and filename:
-            os.makedirs(self._storage_path, exist_ok=True)
-            hs = torch.cat(self._accumulated_hs.pop(req_id), dim=0)
-            token_ids_list = self._accumulated_tokens.pop(req_id, [])
-            tensors = {
-                "hidden_states": hs,
-                "token_ids": torch.tensor(token_ids_list),
-            }
-            safetensors.torch.save_file(tensors, filename)
-
+        # File was already written by save_hidden_states() on the worker.
         return False, {"hidden_states_path": filename}
 
     def request_finished_all_groups(

--- a/vllm/v1/spec_decode/extract_hidden_states.py
+++ b/vllm/v1/spec_decode/extract_hidden_states.py
@@ -6,48 +6,36 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-import torch.nn as nn
 
-from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
-from vllm.forward_context import set_forward_context
-from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
-from vllm.model_executor.model_loader import get_model
-from vllm.v1.attention.backend import AttentionMetadataBuilder, CommonAttentionMetadata
-from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
-from vllm.v1.worker.dp_utils import coordinate_batch_across_dp
+from vllm.config import CUDAGraphMode, VllmConfig
+from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 
 if TYPE_CHECKING:
     from vllm.v1.kv_cache_interface import KVCacheConfig
 
-PADDING_SLOT_ID = -1
-
 
 class ExtractHiddenStatesProposer:
+    """Proposer that extracts hidden states and passes them directly to the
+    KV connector, bypassing the KV cache entirely.
+
+    Instead of loading a draft model with CacheOnly attention layers and
+    routing hidden states through the KV cache pipeline, this proposer
+    stacks the target model's intermediate hidden states and hands them
+    to the connector's ``save_hidden_states()`` method.  This avoids
+    any interaction with the KV cache group/coordinator machinery, making
+    it compatible with hybrid models (e.g. Qwen3.5) without modifications
+    to core KV cache code.
+    """
+
     def __init__(self, vllm_config: VllmConfig, device):
         assert vllm_config.speculative_config is not None
-
         assert vllm_config.speculative_config.num_speculative_tokens == 1
-        if vllm_config.speculative_config.disable_padded_drafter_batch:
-            raise ValueError(
-                "disable_padded_drafter_batch is not supported with "
-                "extract_hidden_states method"
-            )
+
         self.vllm_config = vllm_config
         self.device = device
         self.dtype = vllm_config.model_config.dtype
         self.dp_rank = vllm_config.parallel_config.data_parallel_rank
-
-        # Model and attention layer tracking (initialized in load_model)
-        self.model: nn.Module | None = None
-        self.attn_layer_names: list[str] = []
-        self.attn_metadata_builder: AttentionMetadataBuilder | None = None
-
-        # Maximum number of tokens for buffers
-        max_batch_size = vllm_config.scheduler_config.max_num_seqs
-        self.max_num_tokens = (
-            vllm_config.scheduler_config.max_num_batched_tokens + max_batch_size
-        )
 
         self.hf_config = vllm_config.speculative_config.draft_model_config.hf_config
         layer_ids = getattr(self.hf_config, "eagle_aux_hidden_state_layer_ids", None)
@@ -58,16 +46,9 @@ class ExtractHiddenStatesProposer:
             )
         self.num_hidden_states = len(layer_ids)
         self.hidden_size = vllm_config.model_config.get_hidden_size()
-        self.hidden_states = torch.zeros(
-            (self.max_num_tokens, self.num_hidden_states, self.hidden_size),
-            dtype=self.dtype,
-            device=device,
-        )
-        self.cudagraph_dispatcher = CudagraphDispatcher(self.vllm_config)
 
-        self._slot_mapping_buffer = torch.zeros(
-            self.max_num_tokens, dtype=torch.int64, device=device
-        )
+        # No draft model, no attention metadata, no CUDAGraphs, no buffers.
+        self.model = None
 
     def propose(
         self,
@@ -78,161 +59,29 @@ class ExtractHiddenStatesProposer:
         | list[dict[str, torch.Tensor]]
         | None = None,
     ) -> torch.Tensor:
-        """Propose draft tokens by calling the ExtractHiddenStatesModel model.
+        """Stack hidden states and pass them to the KV connector directly."""
+        assert isinstance(target_hidden_states, list)
 
-        The ExtractHiddenStatesModel caches the hidden states in the KV cache
-        without performing actual attention computation. This allows us to
-        extract and store hidden states for later use (e.g., KV transfer).
+        # [num_tokens, num_hidden_states, hidden_size]
+        stacked = torch.stack(target_hidden_states, dim=1)
 
-        This proposer doesn't actually perform speculation - it returns the
-        sampled tokens as "draft" tokens, ensuring they always verify (match).
-        The main purpose is to cache hidden states, not to speculate.
-
-        Args:
-            sampled_token_ids: Sampled token IDs from the target model
-            target_hidden_states: List of hidden state tensors from target model
-                                (one per aux hidden state layer)
-            common_attn_metadata: Attention metadata
-            slot_mappings: Slot mappings for KV cache (unused, provided for
-                          interface compatibility)
-
-        Returns:
-            Tuple of:
-                - Draft tokens matching sampled tokens, shape [batch_size, 1]
-                - KV connector output (if KV transfer is active), else None
-        """
-        assert self.model is not None and isinstance(target_hidden_states, list)
-
-        # target_hidden_states is a list of tensors (one per layer)
-        # Each tensor has shape [num_tokens, hidden_size]
-        # Stack to shape: [num_tokens, num_hidden_states, hidden_size]
-        stacked_hidden_states = torch.stack(target_hidden_states, dim=1)
-        num_tokens = stacked_hidden_states.shape[0]
-
-        # Copy hidden states to buffer
-        self.hidden_states[:num_tokens] = stacked_hidden_states
-
-        assert self.attn_metadata_builder is not None
-        attn_metadata = self.attn_metadata_builder.build_for_drafting(
-            common_attn_metadata=common_attn_metadata, draft_index=0
+        from vllm.distributed.kv_transfer import (
+            get_kv_transfer_group,
+            has_kv_transfer_group,
         )
 
-        # We assume all cache-only layers belong to the same KV cache group,
-        # thus using the same attention metadata.
-        per_layer_attn_metadata = {}
-        for layer_name in self.attn_layer_names:
-            per_layer_attn_metadata[layer_name] = attn_metadata
+        if has_kv_transfer_group():
+            connector = get_kv_transfer_group()
+            if hasattr(connector, "save_hidden_states"):
+                qsl = common_attn_metadata.query_start_loc_cpu
+                tokens_per_req = (qsl[1:] - qsl[:-1]).tolist()
+                connector.save_hidden_states(stacked, tokens_per_req)
 
-        cudagraph_runtime_mode, num_input_tokens, num_tokens_across_dp = (
-            self._determine_batch_execution_and_padding(num_tokens)
-        )
-        if num_tokens_across_dp is not None:
-            num_tokens_across_dp[self.dp_rank] = num_input_tokens
-
-        with set_forward_context(
-            per_layer_attn_metadata,
-            self.vllm_config,
-            num_tokens=num_input_tokens,
-            num_tokens_across_dp=num_tokens_across_dp,
-            cudagraph_runtime_mode=cudagraph_runtime_mode,
-            slot_mapping=self._get_slot_mapping(
-                num_input_tokens, common_attn_metadata.slot_mapping
-            ),
-        ):
-            self.model(
-                hidden_states=self.hidden_states[:num_input_tokens],
-            )
-
-        # Return the sampled tokens as "draft" tokens
-        # Shape: [batch_size, 1] to match num_speculative_tokens=1
-        # On decode steps with spec tokens, sampled_token_ids may have
-        # shape [batch_size, 2] (target + spec verification); slice to
-        # return only the target-sampled column.
         return sampled_token_ids[:, :1]
 
-    def _get_slot_mapping(
-        self,
-        num_tokens: int,
-        slot_mapping: torch.Tensor | None = None,
-    ) -> dict[str, torch.Tensor]:
-        """Return slot_mapping dict for cache-only attention layers.
+    def load_model(self, target_model) -> None:
+        """No draft model to load in bypass mode."""
 
-        If slot_mapping is provided, copies it into the buffer first.
-        """
-        if slot_mapping is not None:
-            num_actual = slot_mapping.shape[0]
-            self._slot_mapping_buffer[:num_actual].copy_(slot_mapping)
-            if num_tokens > num_actual:
-                self._slot_mapping_buffer[num_actual:num_tokens].fill_(PADDING_SLOT_ID)
-
-        view = self._slot_mapping_buffer[:num_tokens]
-        return {name: view for name in self.attn_layer_names}
-
-    def _determine_batch_execution_and_padding(
-        self,
-        num_tokens: int,
-        use_cudagraphs: bool = True,
-    ) -> tuple[CUDAGraphMode, int, torch.Tensor | None]:
-        cudagraph_mode, batch_desc = self.cudagraph_dispatcher.dispatch(
-            num_tokens,
-            valid_modes=({CUDAGraphMode.NONE} if not use_cudagraphs else None),
-        )
-        num_tokens_padded = batch_desc.num_tokens
-
-        # Extra coordination when running data-parallel since we need to
-        # coordinate across ranks
-        # TODO(Flechman): support DBO ubatching
-        should_ubatch, num_tokens_across_dp = False, None
-        if self.vllm_config.parallel_config.data_parallel_size > 1:
-            should_ubatch, num_tokens_across_dp, synced_cudagraph_mode = (
-                coordinate_batch_across_dp(
-                    num_tokens_unpadded=num_tokens,
-                    parallel_config=self.vllm_config.parallel_config,
-                    allow_microbatching=False,
-                    num_tokens_padded=num_tokens_padded,
-                    cudagraph_mode=cudagraph_mode.value,
-                )
-            )
-            assert not should_ubatch, (
-                "DBO ubatching not implemented for extract_hidden_states"
-            )
-
-            # Extract DP-synced values
-            if num_tokens_across_dp is not None:
-                dp_rank = self.dp_rank
-                num_tokens_padded = int(num_tokens_across_dp[dp_rank].item())
-                # Re-dispatch with DP padding so we have the correct
-                # batch_descriptor
-                cudagraph_mode, batch_desc = self.cudagraph_dispatcher.dispatch(
-                    num_tokens_padded,
-                    valid_modes={CUDAGraphMode(synced_cudagraph_mode)},
-                )
-                # Assert to make sure the agreed upon token count is correct
-                # otherwise num_tokens_across_dp will no-longer be valid
-                assert batch_desc.num_tokens == num_tokens_padded
-                num_tokens_across_dp[dp_rank] = num_tokens_padded
-
-        return cudagraph_mode, num_tokens_padded, num_tokens_across_dp
-
-    def initialize_cudagraph_keys(self, cudagraph_mode: CUDAGraphMode) -> None:
-        """Initialize cudagraph dispatcher keys.
-
-        Only supports PIECEWISE cudagraphs (via mixed_mode).
-        Should be called after adjust_cudagraph_sizes_for_spec_decode.
-        """
-        assert self.vllm_config.speculative_config is not None
-        if (
-            not self.vllm_config.speculative_config.enforce_eager
-            and cudagraph_mode.mixed_mode()
-            in [CUDAGraphMode.PIECEWISE, CUDAGraphMode.FULL]
-        ):
-            proposer_cudagraph_mode = CUDAGraphMode.PIECEWISE
-        else:
-            proposer_cudagraph_mode = CUDAGraphMode.NONE
-
-        self.cudagraph_dispatcher.initialize_cudagraph_keys(proposer_cudagraph_mode)
-
-    @torch.inference_mode()
     def dummy_run(
         self,
         num_tokens: int,
@@ -240,52 +89,13 @@ class ExtractHiddenStatesProposer:
         is_graph_capturing: bool = False,
         slot_mappings: dict[str, torch.Tensor] | None = None,
     ) -> None:
-        assert self.model is not None, "Model must be initialized before dummy_run"
-        cudagraph_runtime_mode, num_input_tokens, num_tokens_across_dp = (
-            self._determine_batch_execution_and_padding(
-                num_tokens, use_cudagraphs=use_cudagraphs
-            )
-        )
+        """No draft model to warm up."""
 
-        if num_tokens_across_dp is not None:
-            num_tokens_across_dp[self.dp_rank] = num_input_tokens
+    def initialize_cudagraph_keys(self, cudagraph_mode: CUDAGraphMode) -> None:
+        """No CUDAGraphs for the proposer."""
 
-        # Use our own slot mapping buffer during cudagraph capture.
-        if (
-            self.attn_layer_names
-            and slot_mappings is not None
-            and self.attn_layer_names[0] in slot_mappings
-        ):
-            slot_mapping_dict = self._get_slot_mapping(num_input_tokens)
-        else:
-            slot_mapping_dict = slot_mappings or {}
-
-        with set_forward_context(
-            None,
-            self.vllm_config,
-            num_tokens=num_input_tokens,
-            num_tokens_across_dp=num_tokens_across_dp,
-            cudagraph_runtime_mode=cudagraph_runtime_mode,
-            slot_mapping=slot_mapping_dict,
-        ):
-            self.model(
-                hidden_states=self.hidden_states[:num_input_tokens],
-            )
-
-    def _build_attn_metadata_builder(
-        self, draft_attn_layers: dict[str, AttentionLayerBase]
-    ) -> AttentionMetadataBuilder:
-        """Build the attention metadata builder from draft attention layers."""
-        if not draft_attn_layers:
-            raise ValueError("No attention layers found for ExtractHiddenStatesModel")
-        layer = next(iter(draft_attn_layers.values()))
-        attn_backend = layer.get_attn_backend()
-        return attn_backend.get_builder_cls()(
-            layer.get_kv_cache_spec(self.vllm_config),
-            self.attn_layer_names,
-            self.vllm_config,
-            self.device,
-        )
+    def validate_same_kv_cache_group(self, kv_cache_config: KVCacheConfig) -> None:
+        """No KV cache groups to validate."""
 
     def prepare_next_token_ids_padded(
         self,
@@ -294,8 +104,7 @@ class ExtractHiddenStatesProposer:
         gpu_input_batch: InputBatch,
         discard_request_mask: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """
-        Prepare next token IDs for speculative decoding.
+        """Prepare next token IDs for speculative decoding.
 
         Since num_speculative_tokens == 1, sampled_token_ids has shape
         (batch_size, 1). For each request we either use the sampled token
@@ -304,7 +113,6 @@ class ExtractHiddenStatesProposer:
         num_reqs = gpu_input_batch.num_reqs
         device = sampled_token_ids.device
 
-        # Compute backup tokens for discarded / invalid requests
         seq_lens_list = (gpu_input_batch.num_tokens_no_spec[:num_reqs] - 1).tolist()
         backup_tokens_gpu = torch.tensor(
             [
@@ -317,7 +125,6 @@ class ExtractHiddenStatesProposer:
 
         assert discard_request_mask.dtype == torch.bool
 
-        # With num_speculative_tokens == 1, there is exactly one token
         sampled = sampled_token_ids[:, 0]
         is_valid = (sampled >= 0) & (sampled < gpu_input_batch.vocab_size)
         valid_sampled_tokens_count = is_valid.to(torch.int32)
@@ -328,55 +135,3 @@ class ExtractHiddenStatesProposer:
         )
 
         return next_token_ids, valid_sampled_tokens_count
-
-    def load_model(self, target_model: nn.Module) -> None:
-        """Load the ExtractHiddenStatesModel model.
-
-        This method instantiates the ExtractHiddenStatesModel model which is used
-        to cache hidden states during speculative decoding. The model uses
-        cache-only attention (no computation, just caching KV states).
-
-        Args:
-            target_model: The target model (passed for compatibility with
-                         EagleProposer interface, but not used here)
-        """
-        # Get the target model's attention layers before loading draft model
-        target_attn_layer_names = set(
-            get_layers_from_vllm_config(self.vllm_config, AttentionLayerBase).keys()  # type: ignore[type-abstract]
-        )
-
-        assert self.vllm_config.speculative_config is not None
-        draft_model_config = self.vllm_config.speculative_config.draft_model_config
-        from vllm.compilation.backends import set_model_tag
-
-        with set_model_tag("extract_hidden_states"):
-            self.model = get_model(
-                vllm_config=self.vllm_config, model_config=draft_model_config
-            )
-
-        # Identify draft model's attention layers (difference from target)
-        all_attn_layers = get_layers_from_vllm_config(
-            self.vllm_config,
-            AttentionLayerBase,  # type: ignore[type-abstract]
-        )
-        draft_attn_layers = {
-            name: layer
-            for name, layer in all_attn_layers.items()
-            if name not in target_attn_layer_names
-        }
-        self.attn_layer_names = list(draft_attn_layers.keys())
-        assert len(draft_attn_layers) == 1, (
-            "ExtractHiddenStatesModel should have exactly one "
-            f"attention layer, found {len(draft_attn_layers)}"
-        )
-        self.attn_metadata_builder = self._build_attn_metadata_builder(
-            draft_attn_layers
-        )
-
-    def validate_same_kv_cache_group(self, kv_cache_config: KVCacheConfig) -> None:
-        """Validate all drafting layers belong to the same KV cache group.
-
-        With exactly one attention layer (asserted in load_model), this is
-        trivially satisfied.
-        """
-        assert len(self.attn_layer_names) == 1


### PR DESCRIPTION
## Summary

- Adds hybrid model support (e.g. Qwen3.5) for `extract_hidden_states` speculative decoding by bypassing the KV cache entirely
- Proposer stacks target-model hidden states and passes them directly to the connector via `save_hidden_states()` — no draft model loaded, no CacheOnly attention layer, no CUDAGraphs
- Connector accumulates per-request hidden states on CPU and writes to disk each step
- **Zero interaction with KV cache** — no `CacheOnlySpec`, no groups, no coordinator changes. Only 3 files changed, net -343 lines
- Gates HMA disable with `supports_hma()` check so hybrid models keep per-group block allocators

**This is 1 of 3 alternative approaches** — see [RFC document](https://github.com/neuralmagic/vllm/blob/hma/extract-hidden-states-bypass/local/explanation/hybrid_hidden_states_rfc.md) and sister PRs for comparison:
- **Approach A:** CacheOnly as filtered KV cache group — neuralmagic/vllm#160
- **Approach B:** CacheOnly as supplementary tensors — neuralmagic/vllm#161
- **Approach C (this PR):** Bypass KV cache entirely (3 files, +139/-482)

## Test plan

- [ ] Verified on Qwen3.5-9B with TP=4, non-zero hidden states extracted
- [ ] Verified on standard (non-hybrid) model — no regression
- [ ] `pre-commit run --all-files` passes on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)