### PR TITLE
[Perf] Fuse RoPE + KV cache update for MLA backends (#35879): eliminate extra Inductor copy + enable on ROCm

### DIFF
--- a/csrc/cache.h
+++ b/csrc/cache.h
@@ -38,7 +38,7 @@ void concat_and_cache_mla_rope_fused(
     torch::Tensor& kv_c, torch::Tensor& rope_cos_sin_cache, bool rope_is_neox,
     torch::Tensor& kv_cache_slot_mapping, torch::Tensor& kv_cache,
     const std::string& kv_cache_dtype, torch::Tensor& kv_cache_quant_scale,
-    bool has_slot_mapping);
+    bool has_slot_mapping, torch::Tensor& k_pe_out);
 
 // Just for unittest
 void convert_fp8(torch::Tensor& dst_cache, torch::Tensor& src_cache,

--- a/csrc/cache_kernels_fused.cu
+++ b/csrc/cache_kernels_fused.cu
@@ -26,7 +26,7 @@ template <typename qk_t, typename cos_sin_t, bool IS_NEOX,
 __global__ void concat_and_cache_mla_rope_fused_kernel(
     const int64_t* __restrict__ positions,  // [num_tokens]
     qk_t* __restrict__ q_pe,        // [num_tokens, num_q_heads, rot_dim]
-    qk_t* __restrict__ k_pe,        // [num_tokens, rot_dim]
+    const qk_t* __restrict__ k_pe,  // [num_tokens, rot_dim] (read-only)
     const qk_t* __restrict__ kv_c,  // [num_tokens, kv_lora_rank]
     const cos_sin_t* __restrict__ rope_cos_sin_cache,  // [max_position, 2,
                                                        // rot_dim // 2]
@@ -37,7 +37,10 @@ __global__ void concat_and_cache_mla_rope_fused_kernel(
                                      // rot_dim)]
     const int64_t* __restrict__ kv_cache_slot_mapping,  // [num_tokens]
     const int block_stride, const int entry_stride, const int kv_lora_rank,
-    const int block_size, const float* kv_cache_quant_scale) {
+    const int block_size, const float* kv_cache_quant_scale,
+    qk_t* __restrict__ k_pe_out  // [num_tokens, rot_dim], contiguous (rot_dim
+                                 // is the head stride)
+) {
   // Each thread block is responsible for one token.
   const int64_t token_idx = blockIdx.x;
   const int64_t pos = positions[token_idx];
@@ -97,7 +100,7 @@ __global__ void concat_and_cache_mla_rope_fused_kernel(
     qk_t cos = static_cast<qk_t>(VLLM_LDG(cos_sin_ptr + pair_idx));
     qk_t sin = static_cast<qk_t>(VLLM_LDG(cos_sin_ptr + pair_idx + embed_dim));
 
-    qk_t* k_pe_head_ptr = k_pe + token_idx * k_pe_stride;
+    const qk_t* k_pe_head_ptr = k_pe + token_idx * k_pe_stride;
 
     int pair_idx_x, pair_idx_y;
     if constexpr (IS_NEOX) {
@@ -116,8 +119,12 @@ __global__ void concat_and_cache_mla_rope_fused_kernel(
     qk_t x_dst = x_src * cos - y_src * sin;
     qk_t y_dst = y_src * cos + x_src * sin;
 
-    k_pe_head_ptr[pair_idx_x] = x_dst;
-    k_pe_head_ptr[pair_idx_y] = y_dst;
+    // Write the rotated k_pe into a fresh contiguous output buffer instead
+    // of mutating the (possibly strided) input view. The kv_cache store
+    // below sees the same rotated value via the local x_dst/y_dst.
+    qk_t* k_pe_out_ptr = k_pe_out + token_idx * rot_dim;
+    k_pe_out_ptr[pair_idx_x] = x_dst;
+    k_pe_out_ptr[pair_idx_y] = y_dst;
 
     // NOTE Why is this monster necessary?
     // When K is of type float16, the actual template replacement for
@@ -185,7 +192,8 @@ __global__ void concat_and_cache_mla_rope_fused_kernel(
                       reinterpret_cast<CACHE_T*>(kv_cache.data_ptr()),         \
                       kv_cache_slot_mapping.data_ptr<int64_t>(), block_stride, \
                       entry_stride, kv_lora_rank, block_size,                  \
-                      kv_cache_quant_scale.data_ptr<float>());                 \
+                      kv_cache_quant_scale.data_ptr<float>(),                  \
+                      k_pe_out.data_ptr<qk_t>());                              \
             } else {                                                           \
               vllm::concat_and_cache_mla_rope_fused_kernel<                    \
                   qk_t, cos_sin_t, false, RAW_KV_T, CACHE_T, KV_DTYPE>         \
@@ -198,7 +206,8 @@ __global__ void concat_and_cache_mla_rope_fused_kernel(
                       reinterpret_cast<CACHE_T*>(kv_cache.data_ptr()),         \
                       kv_cache_slot_mapping.data_ptr<int64_t>(), block_stride, \
                       entry_stride, kv_lora_rank, block_size,                  \
-                      kv_cache_quant_scale.data_ptr<float>());                 \
+                      kv_cache_quant_scale.data_ptr<float>(),                  \
+                      k_pe_out.data_ptr<qk_t>());                              \
             }                                                                  \
           });                                                                  \
     });                                                                        \
@@ -220,7 +229,7 @@ void concat_and_cache_mla_rope_fused(
     torch::Tensor&
         kv_cache,  // [num_blocks, block_size, (kv_lora_rank + rot_dim)]
     const std::string& kv_cache_dtype, torch::Tensor& kv_cache_quant_scale,
-    bool has_slot_mapping) {
+    bool has_slot_mapping, torch::Tensor& k_pe_out) {
   if (!has_slot_mapping) {
     return;
   }
@@ -247,6 +256,13 @@ void concat_and_cache_mla_rope_fused(
   TORCH_CHECK_EQ(k_pe.size(0), q_pe.size(0));
   TORCH_CHECK_EQ(k_pe.size(2), rot_dim);
   TORCH_CHECK_EQ(k_pe.scalar_type(), q_pe.scalar_type());
+
+  // k_pe_out is the fresh contiguous post-rope key buffer.
+  TORCH_CHECK_EQ(k_pe_out.dim(), 3);
+  TORCH_CHECK_EQ(k_pe_out.size(0), q_pe.size(0));
+  TORCH_CHECK_EQ(k_pe_out.size(2), rot_dim);
+  TORCH_CHECK_EQ(k_pe_out.scalar_type(), q_pe.scalar_type());
+  TORCH_CHECK(k_pe_out.is_contiguous(), "k_pe_out must be contiguous");
 
   TORCH_CHECK_EQ(kv_c.dim(), 2);
   TORCH_CHECK_EQ(kv_c.size(0), q_pe.size(0));

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -579,8 +579,9 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _cache_ops), cache_ops) {
       "                     Tensor slot_mapping,"
       "                     Tensor! kv_cache,"
       "                     str kv_cache_dtype,"
-      "                     Tensor kv_cache_scale, bool has_slot_mapping) -> "
-      "()");
+      "                     Tensor kv_cache_scale,"
+      "                     bool has_slot_mapping,"
+      "                     Tensor! k_pe_out) -> ()");
   cache_ops.impl("concat_and_cache_mla_rope_fused", torch::kCUDA,
                  &concat_and_cache_mla_rope_fused);
 

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2600,6 +2600,7 @@ def concat_and_cache_mla_rope_fused(
     kv_cache_dtype: str,
     kv_cache_scale: torch.Tensor,
     has_slot_mapping: bool,
+    k_pe_out: torch.Tensor,
 ) -> None:
     torch.ops._C_cache_ops.concat_and_cache_mla_rope_fused(
         positions,
@@ -2613,6 +2614,7 @@ def concat_and_cache_mla_rope_fused(
         kv_cache_dtype,
         kv_cache_scale,
         has_slot_mapping,
+        k_pe_out,
     )
 
 

--- a/vllm/compilation/passes/fusion/kv_cache_mla_rope_fusion.py
+++ b/vllm/compilation/passes/fusion/kv_cache_mla_rope_fusion.py
@@ -32,6 +32,17 @@ logger = init_logger(__name__)
 _ATEN_SLICE_TO_END: int = 9223372036854775807
 
 
+# fused_concat_and_cache_mla_rope returns a fresh contiguous post-rope k_pe
+# tensor (shape [num_tokens, 1, rot_dim]) rather than mutating the strided
+# `k_pe` input view. This lets downstream ops (in particular the opaque
+# unified_mla_attention_with_output, which lives in a separate Inductor
+# partition) read k_pe directly across the partition boundary, avoiding an
+# extra Triton copy kernel that would otherwise be inserted to materialise
+# the strided view. The op still mutates `q_pe` in place (via the original
+# strided slice), and still writes into `kv_cache`; only the k_pe output
+# path changed.
+
+
 def fused_concat_and_cache_mla_rope_impl(
     positions: torch.Tensor,
     q_pe: torch.Tensor,
@@ -52,6 +63,9 @@ def fused_concat_and_cache_mla_rope_impl(
         f"Expected slot_mapping to be a dict, got {type(slot_mapping)}. "
     )
     layer_slot_mapping = slot_mapping.get(layer_name)
+    # Allocate a fresh contiguous output for the post-rope k_pe (see module
+    # comment above the op for why this is not done in-place on `k_pe`).
+    k_pe_out = torch.empty_like(k_pe, memory_format=torch.contiguous_format)
     ops.concat_and_cache_mla_rope_fused(
         positions,
         q_pe,
@@ -64,8 +78,9 @@ def fused_concat_and_cache_mla_rope_impl(
         kv_cache_dtype,
         kv_cache_scale,
         layer_slot_mapping is not None,
+        k_pe_out,
     )
-    return torch.empty(0, device=kv_c.device, dtype=kv_c.dtype)
+    return k_pe_out
 
 
 def fused_concat_and_cache_mla_rope_fake(
@@ -79,14 +94,14 @@ def fused_concat_and_cache_mla_rope_fake(
     kv_cache_scale: torch.Tensor,
     layer_name: LayerNameType,
 ) -> torch.Tensor:
-    return torch.empty(0, dtype=kv_c.dtype, device=kv_c.device)
+    return torch.empty_like(k_pe, memory_format=torch.contiguous_format)
 
 
 direct_register_custom_op(
     op_name="fused_concat_and_cache_mla_rope",
     op_func=fused_concat_and_cache_mla_rope_impl,
     fake_impl=fused_concat_and_cache_mla_rope_fake,
-    mutates_args=["q_pe", "k_pe"],
+    mutates_args=["q_pe"],
 )
 
 
@@ -190,7 +205,15 @@ class KVCacheMLARoPEFusionPattern:
                 kv_cache_scale=k_scale,
                 layer_name=layer_name,
             )
-            return res[0], res[1], res[2]
+            # auto_functionalized layout (mutates_args=["q_pe"]):
+            #   res[0] -> actual op return (k_pe_out, contiguous)
+            #   res[1] -> mutated q_pe
+            # The pattern's first slot must stay rank-1 (it feeds
+            # `kv_cache_dummy_dep` of unified_mla_attention_with_output, which
+            # the original pattern produced via
+            # unified_mla_kv_cache_update -> torch.empty(0)). Mint a fresh
+            # rank-1 dummy with the same dtype/device.
+            return kv_c_normed.new_empty(0), res[1], res[0]
 
         return pattern, replacement
 
@@ -242,7 +265,8 @@ class KVCacheMLARoPEFusionPattern:
                 kv_cache_scale=k_scale,
                 layer_name=_ln,
             )
-            return res[0], res[1], res[2]
+            # See _mk_pattern_with_layer_name_input for slot semantics.
+            return kv_c_normed.new_empty(0), res[1], res[0]
 
         return pattern, replacement
 
@@ -362,7 +386,7 @@ class KVCacheMLARoPEDeepseekScalingFusionPattern:
             h = self.qk_nope_head_dim + self.qk_rope_head_dim
             v2 = mm.reshape(-1, self.num_heads, h)
             q_pe_slice = v2[:, :, self.qk_nope_head_dim :]
-            res = self.FUSED_OP(
+            k_pe_out = self.FUSED_OP(
                 positions=positions,
                 q_pe=q_pe_slice,
                 k_pe=k_pe,
@@ -373,7 +397,11 @@ class KVCacheMLARoPEDeepseekScalingFusionPattern:
                 kv_cache_scale=k_scale,
                 layer_name=layer_name,
             )
-            return res, v2, k_pe
+            # k_pe_out is the contiguous post-rope key returned by the op.
+            # The first slot must stay rank-1 (it feeds `kv_cache_dummy_dep`
+            # of unified_mla_attention_with_output, originally produced via
+            # unified_mla_kv_cache_update -> torch.empty(0)).
+            return kv_c_normed.new_empty(0), v2, k_pe_out
 
         return pattern, replacement
 
@@ -423,7 +451,7 @@ class KVCacheMLARoPEDeepseekScalingFusionPattern:
             h = self.qk_nope_head_dim + self.qk_rope_head_dim
             v2 = mm.reshape(-1, self.num_heads, h)
             q_pe_slice = v2[:, :, self.qk_nope_head_dim :]
-            res = self.FUSED_OP(
+            k_pe_out = self.FUSED_OP(
                 positions=positions,
                 q_pe=q_pe_slice,
                 k_pe=k_pe,
@@ -434,7 +462,8 @@ class KVCacheMLARoPEDeepseekScalingFusionPattern:
                 kv_cache_scale=k_scale,
                 layer_name=_ln,
             )
-            return res, v2, k_pe
+            # See _mk_pattern_with_layer_name_input for slot semantics.
+            return kv_c_normed.new_empty(0), v2, k_pe_out
 
         return pattern, replacement
 

--- a/vllm/compilation/passes/utility/fix_functionalization.py
+++ b/vllm/compilation/passes/utility/fix_functionalization.py
@@ -193,7 +193,8 @@ class FixFunctionalizationPass(VllmInductorPass):
                 hasattr(torch.ops.vllm, "fused_concat_and_cache_mla_rope")
                 and at_target == torch.ops.vllm.fused_concat_and_cache_mla_rope.default
             ):
-                mutated_args = {1: "q_pe", 2: "k_pe"}
+                # k_pe is now read-only; only q_pe is mutated in place.
+                mutated_args = {1: "q_pe"}
                 self.defunctionalize(
                     graph,
                     node,

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -279,10 +279,10 @@ class PassConfig:
                 "The fusion will be disabled."
             )
             self.fuse_rope_kvcache = False
-        if self.enable_cache_mla_rope_fusion and not current_platform.is_cuda():
+        if self.enable_cache_mla_rope_fusion and not current_platform.is_cuda_alike():
             logger.warning_once(
                 "MLA KV cache update with RoPE fusion enabled but the "
-                "current platform is not CUDA. The fusion will be disabled."
+                "current platform is not CUDA-alike. The fusion will be disabled."
             )
             self.enable_cache_mla_rope_fusion = False
 


### PR DESCRIPTION
Follow-up to #35879. Two changes on top of the fused RoPE + KV cache update for MLA backends:

### 1. Return contiguous `k_pe` from fused kernel (eliminate extra Triton copy)

**Problem:** With the fusion enabled, the post-fusion FX graph has a strided slice of the `qkv_a_proj` output consumed back-to-back by two opaque custom ops:

```
fused_concat_and_cache_mla_rope(... k_pe=unsqueeze_<n> ...)
unified_mla_attention_with_output(..., k_pe=unsqueeze_<n>, ...)
```

Because `k_pe` is a strided alias mutated by the first op and then re-read across the Inductor partition boundary by the second, Inductor materialises it into a fresh contiguous buffer to keep aliasing safe. That materialisation shows up as:

```
triton_poi_fused_fused_concat_and_cache_mla_rope_slice_split_with_sizes_unsqueeze_view_*
```

once per MLA layer (~4.7 µs × 200 steps on Kimi-K2-Thinking-MXFP4/MI355x), nearly doubling the per-layer fused-op cost.

**Fix:** Make the C++ kernel write the rotated `k_pe` into a fresh contiguous output tensor `k_pe_out` (`[num_tokens, 1, rot_dim]`) instead of mutating the strided input view. The kv_cache write inside the kernel still sees the rotated value (rotation stays in registers; only the final store target changes).

**Changes:**
- **C++ kernel + ABI:** `concat_and_cache_mla_rope_fused` gains a trailing `Tensor! k_pe_out` output.
- **Python op wrapper** (`vllm/_custom_ops.py`): allocates `k_pe_out` contiguous like `k_pe` and returns it; drops `k_pe` from `mutates_args`.
- **Fusion pass** (`kv_cache_mla_rope_fusion.py`): rewires downstream consumers to the new contiguous `k_pe_out`.
- **`fix_functionalization.py`**: updated to match the new op signature (3 outputs; only the third — `k_pe_out` — is wired to the new contiguous tensor; the first two get rank-1 `new_empty(0)` slots).

### 2. Enable fusion on ROCm (CUDA-alike platforms)

The config guard in `PassConfig.__post_init__` disabled `enable_cache_mla_rope_fusion` when `current_platform.is_cuda()` returned `False`, which silently prevents the fusion on ROCm even though the pass itself is imported under an `is_cuda_alike()` gate in `pass_manager.py`. Relaxed the guard to `is_cuda_alike()` so ROCm (HIP) gets the same fused path.

## before and after this fusion
### before (PR35789)
<img width="2459" height="63" alt="image" src="https://github.com/user-attachments/assets/394fff63-a53b-45d1-941a-afc5008ba215" />

### after (this PR)

<img width="1485" height="68" alt="image" src="https://github.com/user-attachments/assets/77596a25-d217-42f8-af86-1946bb970b81" />


## Accuracy validation

Tested with Kimi-K2-Thinking-MXFP4 on MI355x with fusion enabled (`enable_cache_mla_rope_fusion: True`):

| Tasks | Version | Filter          | n-shot | Metric      |   | Value |   | Stderr |
|-------|--------:|-----------------|-------:|-------------|---|------:|---|-------:|
| gsm8k |       3 | flexible-extract|      5 | exact_match | ↑ |  0.92 | ± | 0.0172 |
|       |         | strict-match    |      5 | exact_match | ↑ |  0.92 | ± | 0.0172 |

## Test plan

- [x] Accuracy verified on MI355x with fusion enabled (gsm8k 5-shot: 92%)
- [ ] E2E perf run on Kimi-K2-Thinking-MXFP4 in progress.

## Acknowledgements
Thanks @attila-dusnoki-htec for contiguous `k_pe_out` kernel change