### PR TITLE
[EPLB] Wire weight rearrangement for NVFP4 CuteDSL MoE

### DIFF
--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -777,6 +777,7 @@ class EplbState:
                         eplb_model_state,
                         new_physical_to_logical_map=new_physical_to_logical_map,
                     )
+                    _run_after_eplb_rearrangement_hooks(eplb_model_state.model)
 
                 if is_main_rank:
                     assert start_event is not None
@@ -1171,7 +1172,19 @@ def _move_to_workspace(
 
     if result.layer_idx == model_state.model.num_moe_layers - 1:
         model_state.rebalanced = False
+        _run_after_eplb_rearrangement_hooks(model_state.model)
 
     # Reset pending_result before unblocking the async worker
     model_state.pending_result = None
     result.consumed_event.record()
+
+
+def _run_after_eplb_rearrangement_hooks(model: MixtureOfExperts) -> None:
+    """Invoke quant_method.after_eplb_rearrangement on every MoE layer.
+
+    Lets quant methods refresh derived per-expert state (e.g. fused
+    activation x weight scales for NVFP4) that EPLB's Parameter
+    rearrangement won't touch on its own.
+    """
+    for moe_layer in model.moe_layers:
+        moe_layer.quant_method.after_eplb_rearrangement(moe_layer)

--- a/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
@@ -147,6 +147,23 @@ class FusedMoEMethodBase(QuantizeMethodBase):
     def supports_eplb(self) -> bool:
         return False
 
+    def after_eplb_rearrangement(
+        self,
+        layer: "RoutedExperts",  # type: ignore[name-defined] # noqa: F821
+    ) -> None:
+        """Refresh any quant-method state that depends on the per-expert
+        ordering after EPLB has rearranged the registered Parameters.
+
+        EPLB moves registered expert Parameters in-place via P2P, but
+        quant methods often hold *derived* per-expert tensors (e.g. the
+        reciprocal of a global scale, with activation scales fused in)
+        that are separate tensors with their own storage. Those won't
+        be touched by the rearrangement. Override this to re-derive
+        them in place so kernel references stay in sync. Default no-op
+        for methods with no such derived state.
+        """
+        return
+
     @property
     def method_name(self) -> str:
         return self.__class__.__name__

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
@@ -16,11 +16,23 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
 )
 from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
+    NvFp4MoeBackend,
     convert_to_nvfp4_moe_kernel_format,
     is_global_sf_supported_for_nvfp4_backend,
     make_nvfp4_moe_kernel,
     make_nvfp4_moe_quant_config,
     select_nvfp4_moe_backend,
+)
+
+# Backends for which we've verified EPLB rearrangement preserves the
+# layout the kernel expects (registered Parameters are per-expert
+# leading-dim contiguous, derived scales get refreshed in the
+# after_eplb_rearrangement hook).
+_EPLB_SUPPORTED_NVFP4_BACKENDS = frozenset(
+    {
+        NvFp4MoeBackend.FLASHINFER_CUTEDSL,
+        NvFp4MoeBackend.FLASHINFER_CUTEDSL_BATCHED,
+    }
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (  # noqa E501
     CompressedTensorsMoEMethod,
@@ -54,6 +66,15 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
         self.use_global_sf = is_global_sf_supported_for_nvfp4_backend(
             self.nvfp4_backend
         )
+
+    @property
+    def supports_eplb(self) -> bool:
+        # Online / static rearrangement is wired up only for the
+        # CuteDSL backends. Other NVFP4 backends still need their
+        # post-process layout (e.g. TRTLLM weight pre-shuffle, Marlin
+        # repacking) audited for per-expert leading-dim contiguity
+        # before EPLB can rearrange them safely.
+        return self.nvfp4_backend in _EPLB_SUPPORTED_NVFP4_BACKENDS
 
     def create_weights(
         self,
@@ -221,9 +242,35 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
         )
 
         replace_parameter(layer, "w13_weight", w13)
-        replace_parameter(layer, "w13_weight_scale", w13_scale)
         replace_parameter(layer, "w2_weight", w2)
-        replace_parameter(layer, "w2_weight_scale", w2_scale)
+
+        if self.nvfp4_backend == NvFp4MoeBackend.FLASHINFER_CUTEDSL:
+            # flashinfer's convert_sf_to_mma_layout returns a strided
+            # permuted view (shape (32, 4, m_t, 4, k_t, E)) of contiguous
+            # storage laid out as (E, m_t, k_t, 32, 4, 4). EPLB needs a
+            # per-expert leading-dim contiguous view to slice/move
+            # individual experts. The MMA view's permute is
+            # (3, 4, 1, 5, 2, 0); its inverse is (5, 2, 4, 0, 1, 3),
+            # which lands on the underlying (E, ...) contiguous layout
+            # while sharing storage. Register that as the Parameter and
+            # stash the MMA view on the layer as a plain tensor
+            # attribute for the kernel to consume via
+            # get_fused_moe_quant_config.
+            w13_scale_eplb_view = w13_scale.permute(5, 2, 4, 0, 1, 3)
+            w2_scale_eplb_view = w2_scale.permute(5, 2, 4, 0, 1, 3)
+            assert w13_scale_eplb_view.is_contiguous(), (
+                "Expected the inverse-permuted scale view to be contiguous; "
+                "flashinfer's convert_sf_to_mma_layout storage layout may "
+                "have changed."
+            )
+            assert w2_scale_eplb_view.is_contiguous()
+            layer.w13_weight_scale_mma_view = w13_scale
+            layer.w2_weight_scale_mma_view = w2_scale
+            replace_parameter(layer, "w13_weight_scale", w13_scale_eplb_view)
+            replace_parameter(layer, "w2_weight_scale", w2_scale_eplb_view)
+        else:
+            replace_parameter(layer, "w13_weight_scale", w13_scale)
+            replace_parameter(layer, "w2_weight_scale", w2_scale)
         layer.w13_weight_scale_2 = w13_scale_2
         layer.w2_weight_scale_2 = w2_scale_2
         layer.w13_input_scale = a13_scale
@@ -250,14 +297,46 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
         )
 
     def get_fused_moe_quant_config(self, layer: torch.nn.Module) -> FusedMoEQuantConfig:
+        if self.nvfp4_backend == NvFp4MoeBackend.FLASHINFER_CUTEDSL:
+            # Kernel consumes the strided MMA-layout view; the
+            # registered Parameter is the E-leading view of the same
+            # storage so EPLB can rearrange per-expert. Both alias the
+            # same memory -- updates from either propagate.
+            w13_scale = layer.w13_weight_scale_mma_view
+            w2_scale = layer.w2_weight_scale_mma_view
+        else:
+            w13_scale = layer.w13_weight_scale
+            w2_scale = layer.w2_weight_scale
         return make_nvfp4_moe_quant_config(
             backend=self.nvfp4_backend,
-            w13_scale=layer.w13_weight_scale,
-            w2_scale=layer.w2_weight_scale,
+            w13_scale=w13_scale,
+            w2_scale=w2_scale,
             w13_scale_2=layer.w13_weight_scale_2,
             w2_scale_2=layer.w2_weight_scale_2,
             a13_scale=layer.w13_input_scale,
             a2_scale=layer.w2_input_scale,
+        )
+
+    def after_eplb_rearrangement(self, layer: RoutedExperts) -> None:
+        if self.nvfp4_backend not in _EPLB_SUPPORTED_NVFP4_BACKENDS:
+            return
+        # EPLB moves the registered Parameters (w13_weight,
+        # w13_weight_scale, w13_weight_global_scale, w13_input_global_scale,
+        # and their w2 counterparts) per-expert. But the kernel-facing
+        # derived tensor layer.w13_weight_scale_2 holds the fused
+        # product (1 / w13_weight_global_scale) * w13_input_scale (see
+        # FlashInferCuteDSLExperts.process_weights_after_loading, which
+        # does the .mul_ in place). Its storage is independent of
+        # w13_weight_global_scale, so it doesn't get rearranged with the
+        # globals. Re-derive it in place so the kernel's captured
+        # references stay in sync. ``w13_input_scale`` is a max-broadcast
+        # scalar -- invariant under expert permutation, no refresh
+        # needed.
+        layer.w13_weight_scale_2.copy_(
+            (1.0 / layer.w13_weight_global_scale[:, 0]) * layer.w13_input_scale
+        )
+        layer.w2_weight_scale_2.copy_(
+            (1.0 / layer.w2_weight_global_scale) * layer.w2_input_scale
         )
 
     def apply_monolithic(


### PR DESCRIPTION
## Summary

Enable EPLB weight rearrangement for NVFP4 MoE on the FlashInfer CuteDSL backends (Standard and Batched). Previously `CompressedTensorsW4A4Nvfp4MoEMethod` returned `supports_eplb = False`, so any `--enable-eplb` invocation against an NVFP4 checkpoint failed at the `FusedMoE.__init__` gate. This unblocks both online and static (`--eplb-config.load_path`) rearrangement on Mistral-Large-3-NVFP4 and any other NVFP4 MoE using a CuteDSL kernel.

## Background

EPLB rearrangement needs two things from a quant method:

1. **Registered Parameters whose leading dim is `local_num_experts` and is contiguous in storage**, so `rearrange_expert_weights_inplace` can do per-expert P2P send/recv against the layer's real tensors.
2. **A way to refresh any derived per-expert state** that lives outside the registered Parameters (e.g. fused scale products in tensor attributes), since EPLB only touches Parameters.

NVFP4 CuteDSL violates both today:

- After `process_weights_after_loading`, `w13_weight_scale` / `w2_weight_scale` are *strided permuted views* (`(32, 4, m_t, 4, k_t, E)`) returned by flashinfer's `convert_sf_to_mma_layout`. Per its docstring, the underlying storage *is* `(E, m_t, k_t, 32, 4, 4)` contiguous — but the registered Parameter doesn't expose that.
- `layer.w13_weight_scale_2` and `layer.w2_weight_scale_2` are *separate tensors* (own storage), holding the kernel-facing `(1 / w_global_scale) * input_scale` fused product. The expert's `process_weights_after_loading` mutates them in-place via `.mul_(input_scale)`. EPLB rearranges `w13_weight_global_scale` (a Parameter) without knowing about the derived fused product, so after rearrangement the kernel reads scale_2 against the old expert ordering.

## Changes

### 1. Per-expert leading-dim view of MMA-layout scales — `compressed_tensors_moe_w4a4_nvfp4.py`

For the `FLASHINFER_CUTEDSL` backend, the inverse permute of `(3, 4, 1, 5, 2, 0)` is `(5, 2, 4, 0, 1, 3)`. Applying it to the MMA view returns to the underlying `(E, m_t, k_t, 32, 4, 4)` contiguous layout while sharing storage. The new flow in `process_weights_after_loading`:

- Register the E-leading inverse-permuted view as the `Parameter` (visible to EPLB's `get_expert_weights`).
- Stash the original MMA view as `layer.w{13,2}_weight_scale_mma_view` (plain tensor attribute, not in `named_parameters()`).
- `get_fused_moe_quant_config` reads from `_mma_view` for CuteDSL so the kernel still consumes the strided MMA layout.

`is_contiguous()` is asserted on the inverse-permuted view to fail-fast if flashinfer ever changes the underlying storage layout.

The `FLASHINFER_CUTEDSL_BATCHED` backend goes through `prepare_nvfp4_moe_layer_for_fi_or_cutlass`, which produces E-leading contiguous scales via `swizzle_blockscale`. No permute trick needed; it works as-is.

### 2. `after_eplb_rearrangement` hook — `fused_moe_method_base.py` + `eplb_state.py`

- New no-op default `FusedMoEMethodBase.after_eplb_rearrangement(layer)`.
- `_run_after_eplb_rearrangement_hooks(model)` iterates `model.moe_layers` and dispatches; called from both rearrangement paths:
  - Sync: right after `_commit_eplb_maps` in `EplbState.rearrange`.
  - Async: in `_move_to_workspace` once the last layer commits.
- NVFP4 override refreshes `w13/w2_weight_scale_2` in place via `.copy_()` of `(1 / w_global_scale) * input_scale`, so the kernel's captured quant_config reference picks up the new expert ordering without needing to be rebuilt. `input_scale` is the max-broadcast scalar (invariant under permutation), so no refresh is needed for it.

### 3. Backend-scoped `supports_eplb`

`_EPLB_SUPPORTED_NVFP4_BACKENDS = {FLASHINFER_CUTEDSL, FLASHINFER_CUTEDSL_BATCHED}`. Other NVFP4 backends (TRTLLM pre-shuffle, Cutlass, Marlin, Emulation) still need their post-process layouts audited for per-expert leading-dim contiguity before they can be opted in — leaving them at `False` is the safe default rather than silently breaking them.

## Test plan

End-to-end validation on a P/D-disaggregated Mistral-Large-3-675B-Instruct-2512-NVFP4 deployment on B200:

- [x] **MMLU-Pro accuracy eval** — `nemo-evaluator run_eval --eval_type mmlu_pro` against the chat-completions endpoint after the throughput benchmark on each deployment. **Accuracy: 0.7958** (single decode-worker sweep point). This is the load-bearing test for this PR: it's exactly the case the broken-rearrangement diagnosis predicted would fail — routing tables pointing at moved physical slots, the kernel reading the *old* fused scales, etc. would all show up as a large MMLU-Pro drop.