### PR TITLE
[Refactor] Extract _bucket_layers_by_page_size from DSV4 KV cache config

### DIFF
--- a/docs/design/cuda_graphs_multimodal.md
+++ b/docs/design/cuda_graphs_multimodal.md
@@ -17,6 +17,7 @@ The encoder CUDA Graph system uses a **budget-based capture/replay** strategy, m
 
 * [EncoderCudaGraphManager][vllm.v1.worker.encoder_cudagraph.EncoderCudaGraphManager]: orchestrates capture, replay, greedy packing, and data-parallel execution for encoder CUDA Graphs.
 * [SupportsEncoderCudaGraph][vllm.model_executor.models.interfaces.SupportsEncoderCudaGraph]: a runtime-checkable protocol that models implement to opt-in to encoder CUDA Graphs.
+* [EncoderItemSpec][vllm.v1.worker.encoder_cudagraph_defs.EncoderItemSpec]: describes a single encoder input item (image or video) with its input size and output token count.
 * [BudgetGraphMetadata][vllm.v1.worker.encoder_cudagraph.BudgetGraphMetadata]: holds the captured CUDA Graph and its associated I/O buffers for a single token budget level.
 
 ### Budget-based graph capture
@@ -30,8 +31,7 @@ class BudgetGraphMetadata:
     max_batch_size: int
     max_frames_per_batch: int
     graph: torch.cuda.CUDAGraph
-    input_buffer: torch.Tensor       # e.g. pixel_values
-    metadata_buffers: dict[str, torch.Tensor]  # e.g. embeddings, seq metadata
+    input_buffers: dict[str, torch.Tensor]  # e.g. pixel_values, embeddings, seq metadata
     output_buffer: torch.Tensor      # encoder hidden states
 ```
 
@@ -43,8 +43,8 @@ When a batch of images arrives, the manager sorts images by output token count (
 
 For each graph replay:
 
-1. Zero the pre-allocated `input_buffer`, then copy input tensors (e.g., `pixel_values`) into it.
-2. Zero `metadata_buffers`, then slice-copy precomputed values (e.g., rotary embeddings, sequence metadata).
+1. Call `prepare_encoder_cudagraph_replay_buffers()` to compute buffer values (including `pixel_values` and precomputed metadata) from actual batch inputs.
+2. Zero the pre-allocated `input_buffers`, then slice-copy the replay values into them.
 3. Replay the CUDA Graph.
 4. Clone outputs from `output_buffer` (cloning is necessary since the buffer is reused across replays).
 
@@ -65,19 +65,15 @@ Following <https://github.com/vllm-project/vllm/pull/35963> (ViT full CUDA graph
 
 Models opt-in to encoder CUDA Graphs by implementing the [SupportsEncoderCudaGraph][vllm.model_executor.models.interfaces.SupportsEncoderCudaGraph] protocol. This protocol encapsulates all model-specific logic so that the manager remains model-agnostic. The protocol defines the following methods:
 
-* `get_encoder_cudagraph_config()` — returns static configuration (supported modalities, input key, buffer keys, output hidden size).
+* `get_encoder_cudagraph_config()` — returns static configuration (supported modalities, buffer keys, output hidden size, padding logics, max frames per video).
 * `get_encoder_cudagraph_budget_range(vllm_config)` — returns `(min_budget, max_budget)` for auto-inference of token budgets.
-* `get_encoder_cudagraph_num_items(mm_kwargs)` — returns the number of items (e.g. images) in the batch.
-* `get_encoder_cudagraph_per_item_output_tokens(mm_kwargs)` — returns per-item output token counts, used for greedy packing.
-* `get_encoder_cudagraph_per_item_input_sizes(mm_kwargs)` — returns per-item input sizes (e.g. patch counts), used for DP load balancing.
+* `get_encoder_cudagraph_item_specs(mm_kwargs)` — returns `list[EncoderItemSpec]` describing each item with its input size and output token count. Replaces the former three separate methods (`get_num_items`, `get_per_item_output_tokens`, `get_per_item_input_sizes`).
 * `select_encoder_cudagraph_items(mm_kwargs, indices)` — extracts a sub-batch of items by index, used during greedy packing and DP sharding.
-* `prepare_encoder_cudagraph_capture_inputs(...)` — creates dummy inputs for graph capture.
-* `prepare_encoder_cudagraph_replay_buffers(...)` — computes new buffer values from actual batch inputs before replay.
-* `encoder_cudagraph_forward(...)` — forward pass using precomputed buffers (called during capture and replay).
-* `encoder_eager_forward(...)` — fallback eager forward when no graph fits.
-* `get_input_modality(...)` - return the modality of the inputs.
-* `get_max_frames_per_video()` - return model-specific max frames per video.
-* `postprocess_encoder_output(...)` - post process encoder output, directly call scatter_output_slices by default
+* `prepare_encoder_cudagraph_capture_inputs(...)` — creates dummy inputs for graph capture. Returns `EncoderCudaGraphCaptureInputs` with a single `values: dict[str, torch.Tensor]` that contains all buffers to be recorded into the graph.
+* `prepare_encoder_cudagraph_replay_buffers(mm_kwargs, max_batch_size, max_frames_per_batch)` — computes buffer values from actual batch inputs. Returns `EncoderCudaGraphReplayBuffers` with a `values` dict whose keys match `buffer_keys` in the config.
+* `encoder_cudagraph_forward(inputs: dict[str, torch.Tensor])` — forward pass accepting only fixed-shaped input tensors (the captured `values` dict). Called during both capture and replay. The `pixel_values` tensor is included in `inputs` alongside metadata buffers.
+* `encoder_eager_forward(mm_kwargs)` — fallback eager forward when no graph fits.
+* `postprocess_encoder_output(...)` — post-process encoder output, delegates to `scatter_output_slices` by default.
 
 !!! note
     The `SupportsEncoderCudaGraph` protocol is designed to be model-agnostic. New vision encoder models can opt-in by implementing the protocol methods without modifying the manager.
@@ -103,7 +99,7 @@ Three fields in `CompilationConfig` control encoder CUDA Graphs:
 * `cudagraph_mm_encoder` (`bool`, default `False`) — enable CUDA Graph capture for multimodal encoder. When enabled, captures the full encoder forward as a CUDA Graph for each token budget level.
 * `encoder_cudagraph_token_budgets` (`list[int]`, default `[]`) — token budget levels for capture. If empty (default), auto-inferred from model architecture as power-of-2 levels. User-provided values override auto-inference.
 * `encoder_cudagraph_max_vision_items_per_batch` (`int`, default `0`) — maximum number of images/videos per batch during capture. If 0 (default), auto-inferred as `max_budget // min_budget`.
-* `encoder_cudagraph_max_frames_per_batch` (`int`, default `None`) — maximum number of video frames per batch during capture. If `None` (default), auto-inferred as `encoder_cudagraph_max_vision_items_per_batch * max_frames_per_video` (`max_frames_per_video` is a model-specific value according to its `processing_info`). If we limit the video count per prompt to `0`, it will also be set to `0` (i.e., fall back to image-only mode).
+* `encoder_cudagraph_max_frames_per_batch` (`int`, default `None`) — maximum number of video frames per batch during capture. If `None` (default), auto-inferred as `encoder_cudagraph_max_vision_items_per_batch * max_frames_per_video` (`max_frames_per_video` is a model-specific value from `EncoderCudaGraphConfig`, computed by `get_max_frames_per_video()` on the model). If we limit the video count per prompt to `0`, it will also be set to `0` (i.e., fall back to image-only mode).
 
 ## Usage guide
 

--- a/rust/src/chat/src/parser/mod.rs
+++ b/rust/src/chat/src/parser/mod.rs
@@ -6,10 +6,10 @@ use std::convert::Infallible;
 use std::fmt;
 use std::str::FromStr;
 
-use serde_with::DeserializeFromStr;
+use serde_with::{DeserializeFromStr, SerializeDisplay};
 
 /// Specify which reasoning or tool-call parser implementation to use.
-#[derive(Debug, Clone, PartialEq, Eq, Default, DeserializeFromStr)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, DeserializeFromStr, SerializeDisplay)]
 pub enum ParserSelection {
     /// Use model-based auto-detection.
     #[default]

--- a/rust/src/chat/src/renderer/hf/format.rs
+++ b/rust/src/chat/src/renderer/hf/format.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use minijinja::machinery::ast::{Expr, ForLoop, Set, Stmt};
 use minijinja::machinery::{WhitespaceConfig, parse};
 use minijinja::syntax::SyntaxConfig;
-use serde_with::DeserializeFromStr;
+use serde_with::{DeserializeFromStr, SerializeDisplay};
 
 /// Chat template content format.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -18,7 +18,7 @@ pub enum ChatTemplateContentFormat {
 }
 
 /// Configurable chat-template content format selection.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, DeserializeFromStr)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, DeserializeFromStr, SerializeDisplay)]
 pub enum ChatTemplateContentFormatOption {
     /// Detect the format from the template source.
     #[default]

--- a/rust/src/chat/src/renderer/selection.rs
+++ b/rust/src/chat/src/renderer/selection.rs
@@ -1,10 +1,10 @@
 use std::fmt;
 use std::str::FromStr;
 
-use serde_with::DeserializeFromStr;
+use serde_with::{DeserializeFromStr, SerializeDisplay};
 
 /// Specify which chat renderer implementation to use.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, DeserializeFromStr)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, DeserializeFromStr, SerializeDisplay)]
 pub enum RendererSelection {
     /// Use model-based auto-detection.
     #[default]

--- a/rust/src/engine-core-client/src/client.rs
+++ b/rust/src/engine-core-client/src/client.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::future::{join_all, try_join_all};
+use serde::Serialize;
 use tokio::sync::mpsc;
 use tokio_util::task::AbortOnDropHandle;
 use tracing::{debug, info, trace};
@@ -23,7 +24,7 @@ pub use stream::{EngineCoreOutputStream, EngineCoreStreamOutput};
 
 /// How the frontend acquires its request/response transport with Python
 /// `EngineCoreProc`s.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum TransportMode {
     /// The Rust process owns the startup handshake and allocates or binds the
     /// frontend transport addresses itself before replying to engine

--- a/rust/src/server/src/config.rs
+++ b/rust/src/server/src/config.rs
@@ -2,12 +2,13 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use anyhow::Result;
+use serde::Serialize;
 use serde_json::Value;
 use vllm_chat::{ChatTemplateContentFormatOption, ParserSelection, RendererSelection};
 use vllm_engine_core_client::{CoordinatorMode as EngineCoreCoordinatorMode, TransportMode};
 
 /// How the HTTP server obtains its listening socket.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum HttpListenerMode {
     /// Bind a fresh TCP listener on the given host/port.
     BindTcp { host: String, port: u16 },
@@ -20,7 +21,7 @@ pub enum HttpListenerMode {
 
 /// Which coordinator implementation should be active when one is present for a
 /// frontend client.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum CoordinatorMode {
     /// Do not run a coordinator at all.
     None,
@@ -32,7 +33,7 @@ pub enum CoordinatorMode {
 }
 
 /// Normalized runtime configuration for the minimal OpenAI-compatible server.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Config {
     /// Frontend-to-engine transport setup.
     pub transport_mode: TransportMode,

--- a/rust/src/server/src/lib.rs
+++ b/rust/src/server/src/lib.rs
@@ -7,6 +7,7 @@ mod listener;
 mod lora;
 mod middleware;
 mod routes;
+mod server_info;
 mod state;
 mod utils;
 
@@ -30,6 +31,7 @@ use vllm_text::TextLlm;
 
 use crate::listener::Listener;
 use crate::routes::build_router;
+use crate::server_info::ServerInfoSnapshot;
 use crate::state::AppState;
 
 /// Build the shared application state for one configured model and one engine
@@ -88,7 +90,8 @@ async fn build_state(config: &Config) -> Result<Arc<AppState>> {
     Ok(Arc::new(
         AppState::new(served_model_names, chat)
             .with_log_requests(config.enable_log_requests)
-            .with_request_id_headers(config.enable_request_id_headers),
+            .with_request_id_headers(config.enable_request_id_headers)
+            .with_server_info(ServerInfoSnapshot::from_config(config)),
     ))
 }
 

--- a/rust/src/server/src/routes.rs
+++ b/rust/src/server/src/routes.rs
@@ -6,6 +6,7 @@ mod load;
 mod lora;
 mod metrics;
 pub(crate) mod openai;
+mod server_info;
 mod sleep;
 mod version;
 
@@ -89,6 +90,7 @@ fn build_router_with_options(
             .route("/sleep", post(sleep::sleep))
             .route("/wake_up", post(sleep::wake_up))
             .route("/is_sleeping", get(sleep::is_sleeping))
+            .route("/server_info", get(server_info::server_info))
     }
 
     let enable_request_id_headers = state.enable_request_id_headers;

--- a/rust/src/server/src/routes/server_info.rs
+++ b/rust/src/server/src/routes/server_info.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::Deserialize;
+
+use crate::server_info::ServerInfoConfigFormat;
+use crate::state::AppState;
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum ConfigFormat {
+    Text,
+    Json,
+}
+
+impl From<ConfigFormat> for ServerInfoConfigFormat {
+    fn from(value: ConfigFormat) -> Self {
+        match value {
+            ConfigFormat::Text => Self::Text,
+            ConfigFormat::Json => Self::Json,
+        }
+    }
+}
+
+fn default_config_format() -> ConfigFormat {
+    ConfigFormat::Text
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ServerInfoParams {
+    #[serde(default = "default_config_format")]
+    config_format: ConfigFormat,
+}
+
+/// Get server configuration and environment metadata.
+pub async fn server_info(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<ServerInfoParams>,
+) -> Response {
+    match state.server_info_response(params.config_format.into()) {
+        Some(response) => Json(response).into_response(),
+        None => StatusCode::NOT_FOUND.into_response(),
+    }
+}

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -742,16 +742,23 @@ async fn test_chat_with_engine_outputs(
 }
 
 async fn test_app() -> axum::Router {
+    test_app_with_dev_mode(false).await
+}
+
+async fn test_app_with_dev_mode(dev_mode_enabled: bool) -> axum::Router {
     let (chat, _engine_task) = test_models_with_engine_outputs_and_backend(
         b"engine-openai",
         default_stream_output_specs(),
         Arc::new(FakeChatBackend::new()),
     )
     .await;
-    build_router(Arc::new(AppState::new(
-        vec!["Qwen/Qwen1.5-0.5B-Chat".to_string()],
-        chat,
-    )))
+    build_router_with_dev_mode(
+        Arc::new(AppState::new(
+            vec!["Qwen/Qwen1.5-0.5B-Chat".to_string()],
+            chat,
+        )),
+        dev_mode_enabled,
+    )
 }
 
 async fn test_app_with_request_id_headers() -> (axum::Router, MockEngineTask) {
@@ -1089,6 +1096,23 @@ async fn version_returns_engine_vllm_version() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
+async fn server_info_endpoint_is_dev_mode_only() {
+    let mut app = test_app().await;
+    let response = app
+        .call(
+            Request::builder()
+                .uri("/server_info")
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
 async fn load_lora_adapter_registers_model_and_forwards_lora_request() {
     let (mut app, engine_task) = test_admin_app_with_engine_script(|dealer, push| {
         boxed_test_future(async move {
@@ -1300,6 +1324,23 @@ async fn load_lora_adapter_registers_model_and_forwards_lora_request() {
 
     drop(app);
     engine_task.finish().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn server_info_endpoint_returns_not_found_without_snapshot() {
+    let mut app = test_app_with_dev_mode(true).await;
+    let response = app
+        .call(
+            Request::builder()
+                .uri("/server_info")
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/rust/src/server/src/server_info.rs
+++ b/rust/src/server/src/server_info.rs
@@ -1,0 +1,144 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Value, json};
+
+use crate::config::Config;
+
+const SENSITIVE_VLLM_ENV_PATTERNS: &[&str] =
+    &["KEY", "SECRET", "TOKEN", "PASSWORD", "CREDENTIAL", "AUTH"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ServerInfoConfigFormat {
+    Text,
+    Json,
+}
+
+/// Snapshot returned by `/server_info`.
+#[derive(Debug, Clone)]
+pub(crate) struct ServerInfoSnapshot {
+    vllm_config_text: String,
+    vllm_config_json: Value,
+    vllm_env: BTreeMap<String, String>,
+    system_env: BTreeMap<String, String>,
+}
+
+impl ServerInfoSnapshot {
+    /// Capture the runtime configuration fields available to the Rust frontend.
+    pub(crate) fn from_config(config: &Config) -> Self {
+        let vllm_config_json =
+            serde_json::to_value(config).expect("server info value must serialize");
+
+        Self {
+            vllm_config_text: render_config_text(&vllm_config_json),
+            vllm_config_json,
+            vllm_env: collect_vllm_env(),
+            system_env: collect_system_env(),
+        }
+    }
+
+    pub(crate) fn response(&self, config_format: ServerInfoConfigFormat) -> Value {
+        let vllm_config = match config_format {
+            ServerInfoConfigFormat::Text => Value::String(self.vllm_config_text.clone()),
+            ServerInfoConfigFormat::Json => self.vllm_config_json.clone(),
+        };
+
+        json!({
+            "vllm_config": vllm_config,
+            "vllm_env": self.vllm_env.clone(),
+            "system_env": self.system_env.clone(),
+        })
+    }
+}
+
+fn render_config_text(config: &Value) -> String {
+    match config {
+        Value::Object(fields) => fields
+            .iter()
+            .map(|(key, value)| format!("{key}={}", render_config_text_value(value)))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        _ => render_config_text_value(config),
+    }
+}
+
+fn render_config_text_value(value: &Value) -> String {
+    match value {
+        Value::Null => "None".to_string(),
+        Value::String(value) => value.clone(),
+        _ => value.to_string(),
+    }
+}
+
+fn collect_vllm_env() -> BTreeMap<String, String> {
+    std::env::vars().filter(|(key, _)| is_public_vllm_env_key(key)).collect()
+}
+
+fn is_public_vllm_env_key(key: &str) -> bool {
+    let key = key.to_ascii_uppercase();
+    key.starts_with("VLLM_")
+        && !SENSITIVE_VLLM_ENV_PATTERNS.iter().any(|pattern| key.contains(pattern))
+}
+
+fn collect_system_env() -> BTreeMap<String, String> {
+    BTreeMap::from([
+        ("arch".to_string(), std::env::consts::ARCH.to_string()),
+        ("family".to_string(), std::env::consts::FAMILY.to_string()),
+        ("os".to_string(), std::env::consts::OS.to_string()),
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use serde_json::{Value, json};
+
+    use super::{is_public_vllm_env_key, render_config_text};
+
+    #[test]
+    fn render_config_text_formats_config_snapshot() {
+        let rendered = render_config_text(&json!({
+            "model": "test-model",
+            "served_model_name": ["served-model"],
+            "chat_template": null,
+            "enable_log_requests": true,
+        }));
+        let lines = rendered.lines().collect::<BTreeSet<_>>();
+
+        assert_eq!(
+            lines,
+            BTreeSet::from([
+                "chat_template=None",
+                "enable_log_requests=true",
+                "model=test-model",
+                "served_model_name=[\"served-model\"]",
+            ])
+        );
+        assert_eq!(
+            render_config_text(&Value::String("inline".to_string())),
+            "inline"
+        );
+        assert_eq!(render_config_text(&Value::Null), "None");
+    }
+
+    #[test]
+    fn server_info_env_filter_excludes_sensitive_vllm_keys() {
+        for key in [
+            "VLLM_API_KEY",
+            "VLLM_AUTH_TOKEN",
+            "VLLM_SECRET",
+            "VLLM_PASSWORD",
+            "VLLM_CREDENTIAL_FILE",
+            "vllm_token",
+        ] {
+            assert!(!is_public_vllm_env_key(key), "{key}");
+        }
+    }
+
+    #[test]
+    fn server_info_env_filter_includes_public_vllm_keys() {
+        assert!(is_public_vllm_env_key("VLLM_LOGGING_LEVEL"));
+        assert!(is_public_vllm_env_key("VLLM_USE_MODELSCOPE"));
+        assert!(!is_public_vllm_env_key("OTHER_ENV"));
+    }
+}

--- a/rust/src/server/src/state.rs
+++ b/rust/src/server/src/state.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use serde_json::Value;
 use tokio::time::{Duration, Instant, sleep_until};
 use tracing::warn;
 use vllm_chat::ChatLlm;
@@ -8,6 +9,8 @@ use vllm_engine_core_client::EngineCoreClient;
 use vllm_engine_core_client::protocol::lora::LoraRequest;
 
 use crate::lora::{LoadLoraError, LoraManager, LoraModelResolution, UnloadLoraError};
+
+use crate::server_info::{ServerInfoConfigFormat, ServerInfoSnapshot};
 
 const SHUTDOWN_REFCOUNT_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
@@ -22,6 +25,8 @@ pub struct AppState {
     pub enable_log_requests: bool,
     /// Whether to set X-Request-Id on every HTTP response.
     pub enable_request_id_headers: bool,
+    /// Runtime server information returned by `/server_info`, when available.
+    server_info: Option<ServerInfoSnapshot>,
     /// Number of in-flight inference requests currently owned by this frontend.
     server_load: AtomicU64,
     /// Dynamic LoRA adapter registry.
@@ -47,6 +52,7 @@ impl AppState {
             chat,
             enable_log_requests: false,
             enable_request_id_headers: false,
+            server_info: None,
             server_load: AtomicU64::new(0),
             lora_manager: LoraManager::new(),
         }
@@ -62,6 +68,20 @@ impl AppState {
     pub fn with_request_id_headers(mut self, enabled: bool) -> Self {
         self.enable_request_id_headers = enabled;
         self
+    }
+
+    /// Attach the runtime server information snapshot used by `/server_info`.
+    pub(crate) fn with_server_info(mut self, server_info: ServerInfoSnapshot) -> Self {
+        self.server_info = Some(server_info);
+        self
+    }
+
+    /// Build a `/server_info` response payload.
+    pub(crate) fn server_info_response(
+        &self,
+        config_format: ServerInfoConfigFormat,
+    ) -> Option<Value> {
+        self.server_info.as_ref().map(|server_info| server_info.response(config_format))
     }
 
     /// The primary model name echoed back in API responses (the first served

--- a/tests/kernels/attention/test_cpu_attn.py
+++ b/tests/kernels/attention/test_cpu_attn.py
@@ -258,10 +258,13 @@ def varlen_with_paged_kv(
 
     # KV cache for CPU attention
     cache_dtype = torch.uint8 if is_fp8 else dtype
-    packed_key_cache = torch.empty(
-        num_blocks, num_kv_heads, block_size, head_size, dtype=cache_dtype
+    packed_key_value_cache = torch.empty(
+        num_blocks, num_kv_heads, block_size, head_size * 2, dtype=cache_dtype
     )
-    packed_value_cache = torch.empty_like(packed_key_cache)
+    packed_key_value_cache = packed_key_value_cache.view(
+        (num_blocks, num_kv_heads, block_size * 2, -1)
+    )
+    packed_key_cache, packed_value_cache = packed_key_value_cache.chunk(2, dim=2)
 
     cu_query_lens = torch.tensor([0] + query_lens, dtype=torch.int32).cumsum(
         dim=0, dtype=torch.int32

--- a/tests/parser/test_streaming.py
+++ b/tests/parser/test_streaming.py
@@ -58,7 +58,11 @@ def stream_text(parser, tokenizer, text, request, prompt_token_ids=None):
     for tid in token_ids:
         delta_text = tokenizer.decode([tid])
         result = parser.parse_delta(
-            delta_text, [tid], request, prompt_token_ids=prompt_token_ids
+            delta_text,
+            [tid],
+            request,
+            prompt_token_ids=prompt_token_ids,
+            finished=False,
         )
         prompt_token_ids = None
         results.append(result)
@@ -146,7 +150,11 @@ def stream_chunks(parser, tokenizer, chunks, request_obj):
     for chunk in chunks:
         delta_text = tokenizer.decode(chunk)
         result = parser.parse_delta(
-            delta_text, chunk, request_obj, prompt_token_ids=prompt_token_ids
+            delta_text,
+            chunk,
+            request_obj,
+            prompt_token_ids=prompt_token_ids,
+            finished=False,
         )
         prompt_token_ids = None
         results.append(result)

--- a/tests/v1/core/test_encoder_cache_manager.py
+++ b/tests/v1/core/test_encoder_cache_manager.py
@@ -43,6 +43,7 @@ def test_basic_allocate_and_reuse():
 
     assert cache.check_and_update_cache(req, 0)
     assert "r1" in cache.cached["imgA"]
+    assert cache.request_cached_ids["r1"] == {0}
     assert cache.num_free_slots == 6
 
     # Free twice to bring refcount to 0.
@@ -50,6 +51,7 @@ def test_basic_allocate_and_reuse():
     cache.free_encoder_input(req, 0)
 
     assert not cache.cached["imgA"]
+    assert "r1" not in cache.request_cached_ids
     assert "imgA" in cache.freeable
     assert cache.num_freeable_slots == 10
     assert cache.num_free_slots == 6
@@ -63,10 +65,12 @@ def test_freeing_decreases_refcount_and_moves_to_freeable():
     manager.allocate(req, 0)
 
     assert len(manager.cached["img3"]) == 1
+    assert manager.request_cached_ids["req2"] == {0}
 
     manager.free_encoder_input(req, 0)
 
     assert not manager.cached["img3"]
+    assert "req2" not in manager.request_cached_ids
     assert "img3" in manager.freeable
     assert manager.num_freeable_slots == 10
 
@@ -83,11 +87,13 @@ def test_free_request_frees_all_inputs():
 
     assert len(manager.cached["a"]) == 1
     assert len(manager.cached["b"]) == 1
+    assert manager.request_cached_ids["req3"] == {0, 1}
 
     manager.free(req)
 
     assert not manager.cached["a"]
     assert not manager.cached["b"]
+    assert "req3" not in manager.request_cached_ids
     assert "a" in manager.freeable
     assert "b" in manager.freeable
     assert manager.num_freeable_slots == 10
@@ -108,6 +114,7 @@ def test_eviction_when_cache_is_full():
 
     # 'x' should have been evicted.
     assert "x" not in manager.cached
+    assert "req1" not in manager.request_cached_ids
     assert "x" in manager.get_freed_mm_hashes()
 
 
@@ -137,6 +144,7 @@ def test_has_cache_restores_from_freeable():
     # Should restore from freeable.
     assert manager.check_and_update_cache(req, 0)
     assert len(manager.cached["imgZ"]) == 1
+    assert manager.request_cached_ids["reqY"] == {0}
     assert "imgZ" not in manager.freeable
     assert manager.num_freeable_slots == 6
 
@@ -205,6 +213,7 @@ def test_encoder_cache_with_is_embed_mask():
 
     assert manager.num_free_slots == 92
     assert "img1" in manager.cached
+    assert manager.request_cached_ids["r1"] == {0}
 
     old_size = 100
     new_size = request.mm_features[0].mm_position.get_num_embeds()
@@ -276,6 +285,7 @@ def test_reset_clears_all_state():
     manager.reset()
 
     assert len(manager.cached) == 0
+    assert len(manager.request_cached_ids) == 0
     assert len(manager.freeable) == 0
     assert len(manager.freed) == 0
     assert manager.num_free_slots == 20
@@ -298,6 +308,26 @@ def test_reset_allows_fresh_allocations():
     assert manager.num_free_slots == 2
     assert "img2" in manager.cached
     assert "img1" not in manager.cached
+    assert manager.request_cached_ids["req2"] == {0}
+    assert "req1" not in manager.request_cached_ids
+
+
+def test_free_request_with_duplicate_mm_hashes():
+    """Freeing a request whose two inputs share the same mm_hash must fully
+    clean up request_cached_ids. After the first free_encoder_input call,
+    cached[mm_hash] becomes empty; the second call must still remove the
+    remaining input_id from request_cached_ids."""
+    manager = EncoderCacheManager(cache_size=20)
+
+    req = MockRequest("r1", ["imgA", "imgA"], [4, 4])
+
+    manager.allocate(req, 0)
+    # input 1 has the same hash, so it's already cached.
+    assert manager.check_and_update_cache(req, 1)
+    assert manager.request_cached_ids["r1"] == {0, 1}
+
+    manager.free(req)
+    assert "r1" not in manager.request_cached_ids
 
 
 def test_encoder_decoder_cache_manager_reset():

--- a/tests/v1/kv_offload/cpu/test_gpu_worker.py
+++ b/tests/v1/kv_offload/cpu/test_gpu_worker.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 
 from vllm.platforms import current_platform
+from vllm.utils.math_utils import round_up
 from vllm.utils.torch_utils import set_random_seed
 from vllm.v1.kv_offload.base import (
     CanonicalKVCacheRef,
@@ -90,13 +91,15 @@ def test_transfer(
 
     mmap_region: SharedOffloadRegion | None = None
     if use_shared_memory:
-        cpu_page_size = gpu_page_size_bytes * num_tensors * block_size_factor
+        cpu_page_size = round_up(
+            gpu_page_size_bytes * num_tensors * block_size_factor,
+            SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT,
+        )
         mmap_region = SharedOffloadRegion(
             instance_id=str(uuid.uuid4()),
-            total_size_bytes=num_cpu_blocks * cpu_page_size,
             num_blocks=num_cpu_blocks,
             rank=0,
-            num_workers=1,
+            kv_bytes_per_block=cpu_page_size,
             cpu_page_size=cpu_page_size,
         )
 

--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -40,14 +40,12 @@ def _make_region(
     num_workers: int = 1,
     rank: int = 0,
 ) -> SharedOffloadRegion:
-    total_size_bytes = num_blocks * num_workers * cpu_page_size
-    assert total_size_bytes % PAGE_SIZE == 0
+    assert cpu_page_size % PAGE_SIZE == 0
     return SharedOffloadRegion(
         instance_id=instance_id,
-        total_size_bytes=total_size_bytes,
         num_blocks=num_blocks,
         rank=rank,
-        num_workers=num_workers,
+        kv_bytes_per_block=num_workers * cpu_page_size,
         cpu_page_size=cpu_page_size,
     )
 
@@ -77,14 +75,12 @@ def _multi_region(
     cpu_page_size: int = PAGE_SIZE,
 ):
     """Context manager: create one SharedOffloadRegion per rank, clean up on exit."""
-    total = num_blocks * num_workers * cpu_page_size
     regions = [
         SharedOffloadRegion(
             instance_id=instance_id,
-            total_size_bytes=total,
             num_blocks=num_blocks,
             rank=rank,
-            num_workers=num_workers,
+            kv_bytes_per_block=num_workers * cpu_page_size,
             cpu_page_size=cpu_page_size,
         )
         for rank in range(num_workers)
@@ -104,7 +100,6 @@ def _race_construct(
     cpu_page_size: int = PAGE_SIZE,
 ) -> tuple[list[SharedOffloadRegion], list[Exception]]:
     """Spawn num_workers threads that all race to construct SharedOffloadRegion."""
-    total = num_blocks * num_workers * cpu_page_size
     regions: list[SharedOffloadRegion | None] = [None] * num_workers
     errors: list[Exception] = []
     barrier = threading.Barrier(num_workers)
@@ -114,10 +109,9 @@ def _race_construct(
         try:
             regions[rank] = SharedOffloadRegion(
                 instance_id=instance_id,
-                total_size_bytes=total,
                 num_blocks=num_blocks,
                 rank=rank,
-                num_workers=num_workers,
+                kv_bytes_per_block=num_workers * cpu_page_size,
                 cpu_page_size=cpu_page_size,
             )
         except Exception as e:
@@ -134,7 +128,6 @@ def _race_construct(
 
 def _mp_race_construct_and_write(
     instance_id: str,
-    total_bytes: int,
     num_blocks: int,
     rank: int,
     num_workers: int,
@@ -149,10 +142,9 @@ def _mp_race_construct_and_write(
     try:
         region = SharedOffloadRegion(
             instance_id=instance_id,
-            total_size_bytes=total_bytes,
             num_blocks=num_blocks,
             rank=rank,
-            num_workers=num_workers,
+            kv_bytes_per_block=num_workers * cpu_page_size,
             cpu_page_size=cpu_page_size,
         )
         t = region.create_next_view(cpu_page_size)
@@ -309,7 +301,6 @@ def test_create_next_view_multiprocess_slots(iid):
     the parent verifies each slot lands at the correct interleaved offset."""
     num_workers = 2
     num_blocks = 4
-    total_bytes = num_blocks * num_workers * PAGE_SIZE
 
     ctx = get_mp_context()
     done_queue = ctx.Queue()
@@ -318,10 +309,9 @@ def test_create_next_view_multiprocess_slots(iid):
     # Parent is rank 0 (creator); child is rank 1 (joiner).
     region = SharedOffloadRegion(
         instance_id=iid,
-        total_size_bytes=total_bytes,
         num_blocks=num_blocks,
         rank=0,
-        num_workers=num_workers,
+        kv_bytes_per_block=num_workers * PAGE_SIZE,
         cpu_page_size=PAGE_SIZE,
     )
     try:
@@ -329,7 +319,6 @@ def test_create_next_view_multiprocess_slots(iid):
             target=_mp_race_construct_and_write,
             args=(
                 iid,
-                total_bytes,
                 num_blocks,
                 1,
                 num_workers,
@@ -464,7 +453,6 @@ def test_multiprocess_race_construct_and_write(iid):
     fill_value = rank+1 into their slot; parent verifies interleaved layout."""
     num_workers = 4
     num_blocks = 3
-    total_bytes = num_blocks * num_workers * PAGE_SIZE
 
     ctx = get_mp_context()
     done_queue = ctx.Queue()
@@ -475,7 +463,6 @@ def test_multiprocess_race_construct_and_write(iid):
             target=_mp_race_construct_and_write,
             args=(
                 iid,
-                total_bytes,
                 num_blocks,
                 rank,
                 num_workers,

--- a/tests/v1/kv_offload/cpu/test_swap_blocks_triton.py
+++ b/tests/v1/kv_offload/cpu/test_swap_blocks_triton.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit test for the Triton ``swap_blocks_batch`` fast-path kernel."""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.v1.kv_offload.cpu.swap_blocks_triton import swap_blocks_batch
+
+
+def _addrs(buffers: list[torch.Tensor]) -> torch.Tensor:
+    return torch.tensor([b.data_ptr() for b in buffers], dtype=torch.int64)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="Triton swap fast path requires CUDA"
+)
+def test_triton_swap_copies_source_bytes():
+    # 8-byte-aligned, sub-threshold sizes covering 8 KiB chunk boundaries and
+    # odd tail-mask lengths, with enough descriptors to take the Triton path.
+    sizes = [8, 4096, 8192, 8200, 16384, 4088] * 8
+    src = [torch.randint(256, (s,), dtype=torch.uint8, device="cuda") for s in sizes]
+    dst = [torch.zeros_like(s) for s in src]
+    sizes_t = torch.tensor(sizes, dtype=torch.int64)
+
+    swap_blocks_batch(_addrs(src), _addrs(dst), sizes_t.clone(), bytes_per_chunk=8192)
+    torch.accelerator.synchronize()
+
+    for s, t in zip(src, dst):
+        assert torch.equal(t, s)  # kernel copied the source bytes verbatim

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -8,6 +8,7 @@ The tier manager writes KV cache blocks to disk and reads them back, verifying
 data integrity throughout the process.
 """
 
+import mmap
 import os
 import time
 from unittest.mock import MagicMock
@@ -26,8 +27,8 @@ from vllm.v1.kv_offload.tiering.fs.manager import (
 # Helpers
 # ---------------------------------------------------------------------------
 
-_BLOCK_ELEMENTS = 512 * 1024  # 2 MB per block (float32 × 512K = 2MB)
-_DTYPE = torch.float32
+_BLOCK_ELEMENTS = 128 * mmap.PAGESIZE  # 2MB per block for pagesize 4096.
+_DTYPE: torch.dtype = torch.float32
 _CTX = ReqContext(req_id="test")
 
 _MOCK_VLLM_CONFIG = MagicMock()
@@ -90,6 +91,32 @@ def drain(tier: FileSystemTierManager, max_rounds: int = 40) -> list:
     return results
 
 
+def _page_aligned_zero_tensor(
+    num_blocks: int, block_elements: int, dtype: torch.dtype = _DTYPE
+) -> torch.Tensor:
+    page_size = mmap.PAGESIZE
+    dtype_num_bytes = torch.tensor([], dtype=dtype).element_size()
+
+    num_bytes = num_blocks * block_elements * dtype_num_bytes
+    num_bytes_aligned = num_bytes + page_size
+    t = torch.zeros(num_bytes_aligned, dtype=torch.uint8)
+
+    ptr = t.data_ptr()
+    alignment_offset = ptr % page_size
+    # Move tensor to next page regardless.
+    shift = page_size - alignment_offset
+    t = t[shift : shift + num_bytes]
+    return t.view(dtype).view(num_blocks, block_elements)
+
+
+def _page_aligned_rand_tensor(
+    num_blocks: int, block_elements: int, dtype: torch.dtype = _DTYPE
+) -> torch.Tensor:
+    rand_tensor = _page_aligned_zero_tensor(num_blocks, block_elements)
+    rand_tensor[:] = torch.rand(num_blocks, block_elements, dtype=dtype)
+    return rand_tensor
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -97,7 +124,7 @@ def drain(tier: FileSystemTierManager, max_rounds: int = 40) -> list:
 
 @pytest.fixture
 def fs_tier(tmp_path):
-    tensor = torch.zeros((4, _BLOCK_ELEMENTS), dtype=_DTYPE)
+    tensor = _page_aligned_zero_tensor(4, _BLOCK_ELEMENTS)
     mock_view = memoryview(tensor.numpy())
     tier = FileSystemTierManager(
         offloading_spec=_MOCK_OFFLOADING_SPEC,
@@ -155,7 +182,7 @@ def test_store_then_load_roundtrip(fs_tier):
 
 def test_invalid_path_raises_at_construction():
     """Construction must fail immediately when the config file cannot be written."""
-    tensor = torch.zeros((32, _BLOCK_ELEMENTS), dtype=_DTYPE)
+    tensor = _page_aligned_zero_tensor(32, _BLOCK_ELEMENTS)
     mock_view = memoryview(tensor.numpy())
 
     with pytest.raises(OSError):
@@ -228,7 +255,7 @@ def test_store_load_data_integrity(fs_tier):
     """Data written by store must be exactly recovered by load."""
     tier, tensor = fs_tier
     # Populate tensor with random data
-    tensor[:] = torch.rand((4, _BLOCK_ELEMENTS), dtype=_DTYPE)
+    tensor[:] = _page_aligned_rand_tensor(4, _BLOCK_ELEMENTS)
 
     # Store first 2 blocks
     num_store = 2

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -1408,6 +1408,7 @@ class OpenAIServingResponses(OpenAIServing):
                     delta_token_ids=delta_token_ids,
                     request=request,
                     prompt_token_ids=ctx.last_output.prompt_token_ids,
+                    finished=output.finish_reason is not None,
                 )
             else:
                 delta_message = DeltaMessage(content=output.text)

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -161,6 +161,7 @@ from vllm.model_executor.kernels.linear.scaled_mm.triton import (
     TritonInt8ScaledMMLinearKernel,
 )
 from vllm.model_executor.kernels.linear.scaled_mm.xpu import (
+    XPUFp8BlockScaledMMKernel,
     XPUFP8ScaledMMLinearKernel,
 )
 from vllm.model_executor.kernels.linear.scaled_mm.zentorch import (
@@ -317,6 +318,7 @@ _POSSIBLE_FP8_BLOCK_KERNELS: dict[
         CPUFp8BlockScaledMMKernel,
     ],
     PlatformEnum.XPU: [
+        XPUFp8BlockScaledMMKernel,
         TritonFp8BlockScaledMMKernel,
     ],
 }

--- a/vllm/model_executor/kernels/linear/scaled_mm/__init__.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/__init__.py
@@ -39,6 +39,9 @@ from vllm.model_executor.kernels.linear.scaled_mm.ScaledMMLinearKernel import (
 from vllm.model_executor.kernels.linear.scaled_mm.triton import (
     TritonInt8ScaledMMLinearKernel,
 )
+from vllm.model_executor.kernels.linear.scaled_mm.xpu import (
+    XPUFp8BlockScaledMMKernel,
+)
 from vllm.model_executor.kernels.linear.scaled_mm.zentorch import (
     ZentorchInt8ScaledMMLinearKernel,
 )
@@ -64,4 +67,5 @@ __all__ = [
     "ZentorchInt8ScaledMMLinearKernel",
     "Fp8BlockScaledMMLinearKernel",
     "CPUFp8BlockScaledMMKernel",
+    "XPUFp8BlockScaledMMKernel",
 ]

--- a/vllm/model_executor/kernels/linear/scaled_mm/triton.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/triton.py
@@ -160,7 +160,7 @@ class TritonFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
     @classmethod
     def is_supported(cls, compute_capability=None):
         if not (current_platform.is_cuda_alike() or current_platform.is_xpu()):
-            return False, "only cuda-like and xpu devices are supported."
+            return False, "only CUDA-alike and XPU devices are supported."
         return True, None
 
     def apply_block_scaled_mm(

--- a/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
@@ -5,16 +5,15 @@ from collections.abc import Sequence
 
 import torch
 
-from vllm.model_executor.kernels.linear import (  # noqa: E501
-    FP8ScaledMMLinearKernel,
-    FP8ScaledMMLinearLayerConfig,
-)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticChannelSym,
     kFp8StaticTensorSym,
 )
 from vllm.model_executor.utils import replace_parameter
 from vllm.platforms import current_platform
+
+from .BlockScaledMMLinearKernel import Fp8BlockScaledMMLinearKernel
+from .ScaledMMLinearKernel import FP8ScaledMMLinearKernel, FP8ScaledMMLinearLayerConfig
 
 
 class XPUFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
@@ -84,3 +83,38 @@ class XPUFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
         output_shape: list,
     ) -> torch.Tensor:
         pass
+
+
+class XPUFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
+    @classmethod
+    def is_supported(
+        cls, compute_capability: int | None = None
+    ) -> tuple[bool, str | None]:
+        if not current_platform.is_xpu():
+            return False, "XPUFp8BlockScaledMM only support on XPU"
+        return True, None
+
+    def process_weights_after_loading(self, layer: torch.nn.Module):
+        super().process_weights_after_loading(layer)
+        scale_attr = (
+            "weight_scale_inv" if hasattr(layer, "weight_scale_inv") else "weight_scale"
+        )
+        scale = getattr(layer, scale_attr)
+        replace_parameter(layer, scale_attr, scale.data.t().contiguous())
+
+    def apply_block_scaled_mm(
+        self,
+        A: torch.Tensor,
+        B: torch.Tensor,
+        As: torch.Tensor,
+        Bs: torch.Tensor,
+    ) -> torch.Tensor:
+        # Weight is [N, K]. Use .t() to create a [K, N] view without copying.
+        return torch.ops._xpu_C.fp8_gemm(
+            A,
+            B.t(),
+            self.config.out_dtype,
+            As,
+            Bs,
+            torch.Tensor(),
+        )

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -102,23 +102,26 @@ def _quant_flags_to_group_shape(
 class RoutingMethodType(IntEnum):
     # Default: Softmax -> TopK
     Default = (0,)
-    # Renormalize: TopK -> Softmax/Sigmoid
+    # Renormalize: TopK -> Softmax
     Renormalize = (1,)
     # DeepSeekV3: Sigmoid -> RoutingBiasAdd -> Top2 in group -> Top4 groups
     # -> Top8 experts from the Top4 groups
     DeepSeekV3 = (2,)
     # Llama4: Top1 -> Sigmoid
     Llama4 = (3,)
-    # RenormalizeNaive: Softmax/Sigmoid -> TopK -> Renormalize
+    # RenormalizeNaive: Softmax -> TopK -> Renormalize
     RenormalizeNaive = (4,)
     # TopK: TopK (no softmax)
     TopK = (5,)
     # SigmoidRenorm: Sigmoid -> TopK -> Renormalize (divide by sum of top-K)
     SigmoidRenorm = (6,)
     # MiniMax2: Sigmoid + Bias -> TopK -> ScaledSumNormalize
+    # (routeScale=1.0, epsilon=1e-20)
     MiniMax2 = (7,)
+    # Sigmoid: Sigmoid -> TopK (no renormalization)
+    Sigmoid = (8,)
     # Unspecified
-    Unspecified = (8,)
+    Unspecified = (9,)
     # other routing types (not passed to FlashInfer kernels)
     # Deepseek V4 -> sqrtsoftplus + Bias + Normalize
     DeepseekV4 = (100,)
@@ -132,6 +135,7 @@ def get_routing_method_type(
     renormalize: bool,
     num_expert_group: int | None,
     has_e_score_bias: bool,
+    routed_scaling_factor: float | None = 1.0,
 ) -> RoutingMethodType:
     if scoring_func == "sqrtsoftplus":
         # DeepSeek V4 uses sqrtsoftplus routing with optional routing bias
@@ -142,20 +146,21 @@ def get_routing_method_type(
             return RoutingMethodType.Unspecified
 
     if has_e_score_bias:
-        if (num_expert_group or 0) > 0 and scoring_func == "sigmoid":
-            return RoutingMethodType.DeepSeekV3
-        elif scoring_func == "sigmoid":
-            return RoutingMethodType.MiniMax2
+        if scoring_func == "sigmoid":
+            if not renormalize:
+                return RoutingMethodType.Unspecified
+            if (num_expert_group or 0) > 0:
+                return RoutingMethodType.DeepSeekV3
+            if routed_scaling_factor in (None, 1.0):
+                return RoutingMethodType.MiniMax2
+            return RoutingMethodType.Unspecified
         else:
             return RoutingMethodType.Unspecified
 
     if scoring_func == "sigmoid":
-        if top_k == 1:
-            return RoutingMethodType.Llama4
-        elif renormalize:
+        if renormalize:
             return RoutingMethodType.SigmoidRenorm
-        else:
-            return RoutingMethodType.Unspecified
+        return RoutingMethodType.Sigmoid
 
     if scoring_func == "softmax":
         if renormalize:

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
@@ -257,7 +257,7 @@ class TrtLlmFp8ExpertsMonolithic(TrtLlmFp8ExpertsBase, mk.FusedMoEExpertsMonolit
         router_logits_dtype: torch.dtype | None,
         routing_method: RoutingMethodType,
     ) -> bool:
-        return router_logits_dtype != torch.float32
+        return router_logits_dtype in [torch.bfloat16, torch.float32]
 
     @staticmethod
     def _supports_routing_method(
@@ -279,6 +279,7 @@ class TrtLlmFp8ExpertsMonolithic(TrtLlmFp8ExpertsBase, mk.FusedMoEExpertsMonolit
                 RoutingMethodType.Renormalize,
                 RoutingMethodType.RenormalizeNaive,
                 RoutingMethodType.SigmoidRenorm,
+                RoutingMethodType.Sigmoid,
                 RoutingMethodType.MiniMax2,
                 RoutingMethodType.Simulated,
             ]
@@ -290,6 +291,7 @@ class TrtLlmFp8ExpertsMonolithic(TrtLlmFp8ExpertsBase, mk.FusedMoEExpertsMonolit
                 RoutingMethodType.Renormalize,
                 RoutingMethodType.RenormalizeNaive,
                 RoutingMethodType.SigmoidRenorm,
+                RoutingMethodType.Sigmoid,
                 RoutingMethodType.MiniMax2,
                 RoutingMethodType.Simulated,
             ]
@@ -401,11 +403,6 @@ class TrtLlmFp8ExpertsMonolithic(TrtLlmFp8ExpertsBase, mk.FusedMoEExpertsMonolit
             assert apply_router_weight_on_input
         else:
             assert not apply_router_weight_on_input
-
-        # Currently FI requires bfloat16 routing bias.
-        # https://github.com/flashinfer-ai/flashinfer/issues/2909
-        if e_score_correction_bias is not None:
-            e_score_correction_bias = e_score_correction_bias.to(torch.bfloat16)
 
         out = flashinfer.fused_moe.trtllm_fp8_per_tensor_scale_moe(
             routing_logits=router_logits,

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
@@ -360,7 +360,7 @@ class TrtLlmNvFp4ExpertsMonolithic(
         router_logits_dtype: torch.dtype | None,
         routing_method: RoutingMethodType,
     ) -> bool:
-        return router_logits_dtype != torch.float32
+        return router_logits_dtype in [torch.bfloat16, torch.float32]
 
     def apply(
         self,
@@ -392,11 +392,6 @@ class TrtLlmNvFp4ExpertsMonolithic(
             not apply_router_weight_on_input
             and self.routing_method_type != RoutingMethodType.Llama4
         )
-
-        # Currently FI requires bfloat16 routing bias.
-        # https://github.com/flashinfer-ai/flashinfer/issues/2909
-        if e_score_correction_bias is not None:
-            e_score_correction_bias = e_score_correction_bias.to(torch.bfloat16)
 
         output1_scale_gate_scalar = self.quant_config.g1_alphas
 

--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
@@ -326,6 +326,7 @@ class FusedTopKBiasRouter(BaseRouter):
             renormalize=self.renormalize,
             num_expert_group=None,
             has_e_score_bias=True,
+            routed_scaling_factor=self.routed_scaling_factor,
         )
 
     def _compute_routing(

--- a/vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py
@@ -283,6 +283,7 @@ class GroupedTopKRouter(BaseRouter):
             renormalize=self.renormalize,
             num_expert_group=self.num_expert_group,
             has_e_score_bias=self.e_score_correction_bias is not None,
+            routed_scaling_factor=self.routed_scaling_factor,
         )
 
     def _compute_routing(

--- a/vllm/model_executor/layers/fused_moe/router/zero_expert_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/zero_expert_router.py
@@ -63,6 +63,7 @@ class ZeroExpertRouter(BaseRouter):
             renormalize=self.renormalize,
             num_expert_group=None,
             has_e_score_bias=True,
+            routed_scaling_factor=self.routed_scaling_factor,
         )
 
     def _compute_routing(

--- a/vllm/multimodal/utils.py
+++ b/vllm/multimodal/utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import bisect
 import mimetypes
 from collections import defaultdict
 from collections.abc import Generator, Sequence
@@ -18,6 +19,7 @@ from vllm.utils.import_utils import LazyLoader
 from .hasher import MultiModalHasher
 from .inputs import (
     BatchedTensorInputs,
+    MultiModalFeatureSpec,
     MultiModalFieldElem,
     MultiModalKwargsItem,
     MultiModalSharedField,
@@ -107,6 +109,29 @@ def encode_video_url(
         mimetype = mimetypes.types_map.get("." + format.lower(), "video")
 
     return f"data:{mimetype};base64,{video_b64}"
+
+
+def get_mm_features_in_window(
+    mm_features: list[MultiModalFeatureSpec],
+    start: int,
+    end: int,
+) -> tuple[int, int]:
+    """Return (lo, hi) indices for features overlapping [start, end).
+
+    Assumes mm_features are sorted by offset and non-overlapping, so
+    offset + length is also sorted.
+    """
+    lo = bisect.bisect_left(
+        mm_features,
+        start + 1,
+        key=lambda f: f.mm_position.offset + f.mm_position.length,
+    )
+    hi = bisect.bisect_left(
+        mm_features,
+        end,
+        key=lambda f: f.mm_position.offset,
+    )
+    return lo, hi
 
 
 def argsort_mm_positions(

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -344,7 +344,8 @@ class Parser:
         delta_token_ids: list[int],
         request: ChatCompletionRequest | ResponsesRequest,
         prompt_token_ids: list[int] | None = None,
-        finished: bool = False,
+        *,
+        finished: bool,
     ) -> DeltaMessage | None:
         """Parse a single streaming delta, orchestrating reasoning then
         tool call extraction via internal stream state.
@@ -809,7 +810,8 @@ class DelegatingParser(Parser):
         delta_token_ids: list[int],
         request: ChatCompletionRequest | ResponsesRequest,
         prompt_token_ids: list[int] | None = None,
-        finished: bool = False,
+        *,
+        finished: bool,
     ) -> DeltaMessage | None:
         state = self._stream_state
 

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -110,6 +110,13 @@ class XPUPlatform(Platform):
         dtype: torch.dtype,
         backend: "AttentionBackendEnum | None" = None,
     ) -> "AttentionBackendEnum":
+        if dtype == torch.float32:
+            logger.warning_once(
+                "Flash Attention on XPU does not support float32 dtype. "
+                "Falling back to Triton Attention backend for vit attention."
+            )
+            return AttentionBackendEnum.TRITON_ATTN
+
         if backend is not None:
             assert backend in cls.get_supported_vit_attn_backends(), (
                 f"Backend {backend} is not supported for vit attention. "

--- a/vllm/tool_parsers/glm4_moe_tool_parser.py
+++ b/vllm/tool_parsers/glm4_moe_tool_parser.py
@@ -11,7 +11,6 @@ The fix streams string values incrementally as they arrive, providing a true
 streaming experience for long content.
 """
 
-import ast
 import json
 from collections.abc import Sequence
 from typing import Any
@@ -42,6 +41,7 @@ from vllm.tool_parsers.utils import (
     extract_types_from_schema,
     find_tool_properties,
     partial_tag_overlap,
+    safe_literal_eval,
 )
 
 logger = init_logger(__name__)
@@ -110,7 +110,7 @@ class Glm4MoeModelToolParser(ToolParser):
             pass
 
         try:
-            return ast.literal_eval(value)
+            return safe_literal_eval(value)
         except (ValueError, SyntaxError):
             pass
 

--- a/vllm/tool_parsers/hy_v3_tool_parser.py
+++ b/vllm/tool_parsers/hy_v3_tool_parser.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import ast
 import json
 from collections.abc import Sequence
 from typing import Any
@@ -27,6 +26,7 @@ from vllm.tool_parsers.abstract_tool_parser import (
     Tool,
     ToolParser,
 )
+from vllm.tool_parsers.utils import safe_literal_eval
 
 logger = init_logger(__name__)
 
@@ -183,13 +183,13 @@ class HYV3ToolParser(ToolParser):
 
     @staticmethod
     def _deserialize(value: str) -> Any:
-        """Deserialize a string value using json.loads then ast.literal_eval."""
+        """Deserialize a string value using json.loads then safe_literal_eval."""
         try:
             return json.loads(value)
         except Exception:
             pass
         try:
-            return ast.literal_eval(value)
+            return safe_literal_eval(value)
         except Exception:
             pass
         return value

--- a/vllm/tool_parsers/minicpm5xml_tool_parser.py
+++ b/vllm/tool_parsers/minicpm5xml_tool_parser.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import ast
 import json
 from collections.abc import Sequence
 from typing import Any
@@ -28,7 +27,7 @@ from vllm.tool_parsers.abstract_tool_parser import (
     Tool,
     ToolParser,
 )
-from vllm.tool_parsers.utils import partial_tag_overlap
+from vllm.tool_parsers.utils import partial_tag_overlap, safe_literal_eval
 from vllm.utils import random_uuid
 
 logger = init_logger(__name__)
@@ -116,7 +115,7 @@ def _parse_arguments(json_value: str) -> tuple[Any, bool]:
         try:
             parsed_value = json.loads(json_value)
         except json.JSONDecodeError:
-            parsed_value = ast.literal_eval(json_value)
+            parsed_value = safe_literal_eval(json_value)
         return parsed_value, True
     except Exception:
         return json_value, False

--- a/vllm/tool_parsers/poolside_v1_tool_parser.py
+++ b/vllm/tool_parsers/poolside_v1_tool_parser.py
@@ -11,7 +11,6 @@ The fix streams string values incrementally as they arrive, providing a true
 streaming experience for long content.
 """
 
-import ast
 import json
 from collections.abc import Sequence
 from typing import Any
@@ -41,6 +40,7 @@ from vllm.tool_parsers.abstract_tool_parser import (
     Tool,
     ToolParser,
 )
+from vllm.tool_parsers.utils import safe_literal_eval
 
 logger = init_logger(__name__)
 
@@ -106,7 +106,7 @@ class PoolsideV1ToolParser(ToolParser):
             pass
 
         try:
-            return ast.literal_eval(value)
+            return safe_literal_eval(value)
         except (ValueError, SyntaxError):
             pass
 

--- a/vllm/tool_parsers/qwen3xml_tool_parser.py
+++ b/vllm/tool_parsers/qwen3xml_tool_parser.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import ast
 import json
 from collections.abc import Sequence
 from typing import Any
@@ -26,7 +25,7 @@ from vllm.tool_parsers.abstract_tool_parser import (
     Tool,
     ToolParser,
 )
-from vllm.tool_parsers.utils import find_tool_properties
+from vllm.tool_parsers.utils import find_tool_properties, safe_literal_eval
 
 logger = init_logger(__name__)
 
@@ -824,7 +823,7 @@ class StreamingXMLToolCallParser:
                     try:
                         parsed_value = json.loads(raw_for_parse)
                     except json.JSONDecodeError:
-                        parsed_value = ast.literal_eval(raw_for_parse)
+                        parsed_value = safe_literal_eval(raw_for_parse)
                     output_arguments = json.dumps(parsed_value, ensure_ascii=False)
                 except Exception:
                     # Fallback: output as string as-is

--- a/vllm/tool_parsers/step3p5_tool_parser.py
+++ b/vllm/tool_parsers/step3p5_tool_parser.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import ast
 import json
 from collections.abc import Sequence
 from typing import Any
@@ -23,6 +22,7 @@ from vllm.entrypoints.openai.engine.protocol import (
 from vllm.logger import init_logger
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers.abstract_tool_parser import Tool, ToolParser
+from vllm.tool_parsers.utils import safe_literal_eval
 
 logger = init_logger(__name__)
 
@@ -1016,7 +1016,7 @@ class StreamingXMLToolCallParser:
                         raw_for_parse = raw_text + "\n"
                     else:
                         raw_for_parse = raw_text
-                    parsed_value = ast.literal_eval(raw_for_parse)
+                    parsed_value = safe_literal_eval(raw_for_parse)
                     output_arguments = json.dumps(parsed_value, ensure_ascii=False)
                 except Exception:
                     # Fallback: output as string as-is

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -3,6 +3,7 @@
 
 import ast
 import json
+import warnings
 from json import JSONDecodeError, JSONDecoder
 from typing import Any, TypeAlias
 
@@ -29,6 +30,12 @@ from vllm.logger import init_logger
 Tool: TypeAlias = ChatCompletionToolsParam | ResponsesTool
 
 logger = init_logger(__name__)
+
+
+def safe_literal_eval(text: str):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", SyntaxWarning)
+        return ast.literal_eval(text)
 
 
 def partial_tag_overlap(text: str, tag: str) -> int:

--- a/vllm/transformers_utils/processors/voxtral.py
+++ b/vllm/transformers_utils/processors/voxtral.py
@@ -44,7 +44,7 @@ class MistralCommonFeatureExtractor:
             if not self.audio_encoder.audio_config.is_streaming:
                 audio = self.audio_encoder.pad(audio, self.sampling_rate)
 
-            audios_processed.append(torch.tensor(audio))
+            audios_processed.append(torch.from_numpy(audio))
 
         return BatchFeature(
             {"audio_arrays": audios_processed}, tensor_type=return_tensors

--- a/vllm/v1/attention/backends/cpu_attn.py
+++ b/vllm/v1/attention/backends/cpu_attn.py
@@ -93,7 +93,7 @@ class CPUAttentionBackend(AttentionBackend):
         head_size: int,
         cache_dtype_str: str = "auto",
     ) -> tuple[int, ...]:
-        return 2, num_blocks, num_kv_heads, block_size, head_size
+        return num_blocks, num_kv_heads, block_size, 2 * head_size
 
     @classmethod
     def get_required_kv_cache_layout(cls) -> "KVCacheLayoutType | None":
@@ -308,7 +308,7 @@ class CPUAttentionBackendImpl(AttentionImpl):
             key: shape = [num_tokens, num_kv_heads, head_size]
             value: shape = [num_tokens, num_kv_heads, head_size]
             kv_cache: shape =
-                [2, num_blocks, num_kv_heads, block_size, head_size]
+                [num_blocks, num_kv_heads, block_size, 2 * head_size]
             attn_metadata: Metadata for attention.
         Returns:
             shape = [num_tokens, num_heads * head_size]
@@ -338,8 +338,12 @@ class CPUAttentionBackendImpl(AttentionImpl):
             )
 
         # For decoder and cross-attention, use KV cache, size are
-        # [num_blocks, num_kv_heads, block_size, head_size]
-        key_cache, value_cache = kv_cache.unbind(0)
+        # [num_blocks, num_kv_heads, block_size, 2 * head_size]
+        # Make a view [num_blocks, num_kv_heads, block_size * 2, head_size]
+        # Then slice KV at dim 2
+        num_blocks, num_kv_heads, block_size, _ = kv_cache.size()
+        kv_cache = kv_cache.view((num_blocks, num_kv_heads, block_size * 2, -1))
+        key_cache, value_cache = kv_cache.chunk(2, dim=2)
 
         # key and value may be None in the case of cross attention. They are
         # calculated once based on the output from the encoder and then cached

--- a/vllm/v1/core/encoder_cache_manager.py
+++ b/vllm/v1/core/encoder_cache_manager.py
@@ -71,6 +71,8 @@ class EncoderCacheManager:
 
         # mm_hash of mm_data => ids of requests that reference the mm_data
         self.cached: dict[str, set[str]] = {}
+        # request_id => set of input_ids cached for that request
+        self.request_cached_ids: dict[str, set[int]] = {}
 
         # mm_hash of mm_data => num_encoder_embeds of the mm_data
         self.freeable: OrderedDict[str, int] = OrderedDict()
@@ -83,6 +85,7 @@ class EncoderCacheManager:
         Called when model weights are updated to invalidate stale embeddings.
         """
         self.cached.clear()
+        self.request_cached_ids.clear()
         self.freeable.clear()
         self.freed.clear()
         self.num_free_slots = self.cache_size
@@ -114,6 +117,7 @@ class EncoderCacheManager:
             self.num_freeable_slots -= num_encoder_embeds
 
         self.cached[mm_hash].add(request.request_id)
+        self.request_cached_ids.setdefault(request.request_id, set()).add(input_id)
         return True
 
     def can_allocate(
@@ -201,22 +205,13 @@ class EncoderCacheManager:
         assert self.num_freeable_slots >= num_encoder_embeds
 
         self.cached[mm_hash].add(request_id)
+        self.request_cached_ids.setdefault(request_id, set()).add(input_id)
         self.num_free_slots -= num_encoder_embeds
         self.num_freeable_slots -= num_encoder_embeds
 
     def get_cached_input_ids(self, request: Request) -> set[int]:
-        """Get all cached multimodal input IDs for a request.
-
-        Returns the set of input IDs whose `mm_hash` exists in the cache map.
-        This includes entries that are currently unreferenced (and thus present
-        in `freeable`); for such entries, freeing for this request will be a
-        no-op.
-        """
-        return {
-            input_id
-            for input_id in range(len(request.mm_features))
-            if request.mm_features[input_id].identifier in self.cached
-        }
+        """Get all cached multimodal input IDs for a request."""
+        return self.request_cached_ids.get(request.request_id, set())
 
     def free_encoder_input(self, request: Request, input_id: int) -> None:
         """Free the request's reference to the encoder input (`mm_data`)
@@ -230,6 +225,12 @@ class EncoderCacheManager:
         """
         req_id = request.request_id
         mm_hash = request.mm_features[input_id].identifier
+        # Always clean up request_cached_ids, even if the mm_hash was
+        # already evicted from cache (e.g. by can_allocate).
+        if req_id in self.request_cached_ids:
+            self.request_cached_ids[req_id].discard(input_id)
+            if not self.request_cached_ids[req_id]:
+                del self.request_cached_ids[req_id]
         # The mm_hash not in cache or the req_id set is empty
         if not self.cached.get(mm_hash, None):
             return
@@ -248,8 +249,7 @@ class EncoderCacheManager:
 
         Typically called when a request is finished, cancelled, or aborted.
         """
-        input_ids = self.get_cached_input_ids(request)
-        for input_id in input_ids:
+        for input_id in list(self.get_cached_input_ids(request)):
             self.free_encoder_input(request, input_id)
 
     def get_freed_mm_hashes(self) -> list[str]:

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -919,13 +919,9 @@ def _pool_bytes_per_block(kv_cache_groups: list[KVCacheGroupSpec]) -> int:
     if all(
         isinstance(g.kv_cache_spec, UniformTypeKVCacheSpecs) for g in kv_cache_groups
     ):
-        # DeepseekV4: shared layout sized by the largest per-page-size bucket.
-        full_mla_spec = cast(UniformTypeKVCacheSpecs, kv_cache_groups[0].kv_cache_spec)
-        layer_tuple_page_bytes = sum(full_mla_spec.get_page_sizes())
-        num_layer_tuples = max(
-            cast(UniformTypeKVCacheSpecs, g.kv_cache_spec).get_num_layer_tuples()
-            for g in kv_cache_groups
-        )
+        buckets = _bucket_layers_by_page_size(kv_cache_groups)
+        layer_tuple_page_bytes = sum(buckets.keys())
+        num_layer_tuples = max(len(slots) for slots in buckets.values())
         return layer_tuple_page_bytes * num_layer_tuples
     group_size = max(len(g.layer_names) for g in kv_cache_groups)
     page_size = get_uniform_page_size([g.kv_cache_spec for g in kv_cache_groups])
@@ -1176,6 +1172,31 @@ def _get_kv_cache_groups_uniform_page_size(
     return create_kv_cache_group_specs(kv_cache_spec, grouped_layers)
 
 
+def _bucket_layers_by_page_size(
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> dict[int, list[list[str]]]:
+    """Bucket layers by page size: ``result[ps][slot_idx] = [layer_names]``.
+
+    Layers from different groups at the same ``slot_idx`` share a block
+    (they have independent block tables so block-id namespaces never collide).
+    """
+    buckets: dict[int, list[list[str]]] = defaultdict(list)
+    for group in kv_cache_groups:
+        spec = group.kv_cache_spec
+        slot_count: dict[int, int] = defaultdict(int)
+        for layer_name in group.layer_names:
+            if isinstance(spec, UniformTypeKVCacheSpecs):
+                ps = spec.kv_cache_specs[layer_name].page_size_bytes
+            else:
+                ps = spec.page_size_bytes
+            slot_idx = slot_count[ps]
+            slot_count[ps] += 1
+            if slot_idx == len(buckets[ps]):
+                buckets[ps].append([])
+            buckets[ps][slot_idx].append(layer_name)
+    return buckets
+
+
 def _get_kv_cache_config_deepseek_v4(
     vllm_config: VllmConfig,
     kv_cache_groups: list[KVCacheGroupSpec],
@@ -1183,49 +1204,23 @@ def _get_kv_cache_config_deepseek_v4(
 ) -> tuple[int, list[KVCacheTensor]]:
     """DeepseekV4 KV cache tensor layout planning.
 
-    Precondition: kv_cache_groups[0] is the full-MLA group; its page sizes
-    define the canonical bucket set. Non-full-MLA groups must have been
-    page_size-padded upstream (see _get_kv_cache_groups_uniform_groups) so
-    every layer's page_size matches one of the full-MLA bucket sizes.
-
-    For each group, bucket its layers by page_size_bytes and place each
-    layer at tuple_idx = position-within-bucket. Emit one KVCacheTensor
-    per (tuple_idx, bucket) whose shared_by is the union of per-group
-    layers at that slot.
+    Emit one KVCacheTensor per (slot_idx, page_size). Layers from different
+    groups at the same slot share a tensor (they have independent block
+    tables so block-id namespaces never collide).
     """
-    full_mla_spec = kv_cache_groups[0].kv_cache_spec
-    assert isinstance(full_mla_spec, UniformTypeKVCacheSpecs)
-    page_sizes = sorted(full_mla_spec.get_page_sizes())
+    buckets = _bucket_layers_by_page_size(kv_cache_groups)
+    page_sizes = sorted(buckets.keys())
     layer_tuple_page_bytes = sum(page_sizes)
-
-    # Pre-bucket each group's layers by page_size (registration order within
-    # bucket). bucketed[g_idx][page_size] = [layer_name, ...].
-    bucketed: list[dict[int, list[str]]] = []
-    for group in kv_cache_groups:
-        assert isinstance(group.kv_cache_spec, UniformTypeKVCacheSpecs)
-        specs = group.kv_cache_spec.kv_cache_specs
-        b: dict[int, list[str]] = defaultdict(list)
-        for name in group.layer_names:
-            b[specs[name].page_size_bytes].append(name)
-        bucketed.append(b)
-
-    # num_layer_tuples = longest bucket list across all groups. For the
-    # full-MLA group this equals the count of layers in the largest
-    # per-page-size bucket (= get_num_layer_tuples()); for SWA sub-groups
-    # this equals the sub-group size (each has a single page_size).
-    num_layer_tuples = max(len(layers) for b in bucketed for layers in b.values())
+    num_layer_tuples = max(len(slots) for slots in buckets.values())
 
     num_blocks = available_memory // (layer_tuple_page_bytes * num_layer_tuples)
     num_blocks = may_override_num_blocks(vllm_config, num_blocks)
 
     kv_cache_tensors: list[KVCacheTensor] = []
-    for tuple_idx in range(num_layer_tuples):
+    for slot_idx in range(num_layer_tuples):
         for ps in page_sizes:
-            shared_by: list[str] = []
-            for b in bucketed:
-                bucket = b.get(ps)
-                if bucket is not None and tuple_idx < len(bucket):
-                    shared_by.append(bucket[tuple_idx])
+            slots = buckets[ps]
+            shared_by = slots[slot_idx] if slot_idx < len(slots) else []
             kv_cache_tensors.append(
                 KVCacheTensor(size=ps * num_blocks, shared_by=shared_by)
             )

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -29,6 +29,7 @@ from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
 )
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.multimodal.encoder_budget import MultiModalBudget
+from vllm.multimodal.utils import get_mm_features_in_window
 from vllm.v1.core.encoder_cache_manager import (
     EncoderCacheManager,
     EncoderDecoderCacheManager,
@@ -1163,21 +1164,22 @@ class Scheduler(SchedulerInterface):
         # trackers for accounting at the encoder input level.
         mm_hashes_to_schedule = set()
         num_embeds_to_schedule = 0
-        for i, mm_feature in enumerate(mm_features):
+
+        lo, hi = get_mm_features_in_window(
+            mm_features,
+            start=num_computed_tokens,
+            end=num_computed_tokens + num_new_tokens + shift_computed_tokens,
+        )
+        # For encoder-decoder, all inputs sit at start_pos=0, so lo=0 always.
+        if self.is_encoder_decoder:
+            lo = 0
+
+        for i in range(lo, hi):
+            mm_feature = mm_features[i]
             start_pos = mm_feature.mm_position.offset
             num_encoder_tokens = mm_feature.mm_position.length
             num_encoder_embeds = mm_feature.mm_position.get_num_embeds()
             item_identifier = mm_feature.identifier
-
-            # The encoder output is needed if the two ranges overlap:
-            # [num_computed_tokens, num_computed_tokens + num_new_tokens) and
-            # [start_pos, start_pos + num_encoder_tokens)
-            if (
-                start_pos
-                >= num_computed_tokens + num_new_tokens + shift_computed_tokens
-            ):
-                # The encoder input is not needed in this step.
-                break
 
             if self.is_encoder_decoder and num_computed_tokens > 0:
                 assert start_pos == 0, (
@@ -1193,10 +1195,6 @@ class Scheduler(SchedulerInterface):
                 # inputs before running the decoder.  Once we've calculated some
                 # decoder tokens (num_computed_tokens > 0), then we know we
                 # already calculated encoder inputs and can skip here.
-                continue
-            elif start_pos + num_encoder_tokens <= num_computed_tokens:
-                # The encoder input is already computed and stored
-                # in the decoder's KV cache.
                 continue
 
             if not self.is_encoder_decoder:

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import functools
 import time
 from collections import deque
 from dataclasses import dataclass
@@ -10,6 +11,7 @@ from typing_extensions import override
 
 from vllm import _custom_ops as ops
 from vllm.logger import init_logger
+from vllm.triton_utils import HAS_TRITON, triton
 from vllm.utils.math_utils import cdiv
 from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.v1.kv_offload.base import (
@@ -19,6 +21,10 @@ from vllm.v1.kv_offload.base import (
     GPULoadStoreSpec,
 )
 from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
+from vllm.v1.kv_offload.cpu.swap_blocks_triton import (
+    THRESHOLD_BYTES,
+    swap_blocks_batch,
+)
 from vllm.v1.kv_offload.worker.worker import (
     OffloadingHandler,
     TransferResult,
@@ -28,6 +34,30 @@ from vllm.v1.kv_offload.worker.worker import (
 logger = init_logger(__name__)
 
 
+def _select_swap_blocks_fn(
+    kv_cache_groups_data_refs: list[list[CanonicalKVCacheRef]],
+    gpu_to_cpu: bool,
+):
+    """Resolve the swap_blocks function for a handler at init time."""
+    # GPU->CPU is bandwidth-bound; the dedicated copy engine beats Triton.
+    if gpu_to_cpu:
+        return ops.swap_blocks_batch
+    # Fall back to the C++ DMA path on platforms where Triton isn't usable
+    # (e.g. ROCm builds without Triton).
+    if not HAS_TRITON:
+        return ops.swap_blocks_batch
+    page_sizes = [r.page_size_bytes for g in kv_cache_groups_data_refs for r in g]
+    # Triton wins only on small, 8-byte-aligned payloads.
+    if (
+        not page_sizes
+        or max(page_sizes) >= THRESHOLD_BYTES
+        or any(s % 8 for s in page_sizes)
+    ):
+        return ops.swap_blocks_batch
+    chunk = min(triton.next_power_of_2(max(page_sizes)), 8192)
+    return functools.partial(swap_blocks_batch, bytes_per_chunk=chunk)
+
+
 @dataclass
 class Transfer:
     job_id: int
@@ -35,6 +65,9 @@ class Transfer:
     start_event: torch.Event
     end_event: torch.Event
     num_bytes: int
+    batch_src: torch.Tensor
+    batch_dst: torch.Tensor
+    batch_sizes: torch.Tensor
 
 
 def compute_sub_block_ptrs(
@@ -109,6 +142,17 @@ def pin_mmap_region(region: SharedOffloadRegion) -> None:
         region.is_pinned = True
 
 
+def _new_descriptor_buffers(
+    num_copy_ops: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    pin = is_pin_memory_available()
+    return (
+        torch.empty(num_copy_ops, dtype=torch.int64, pin_memory=pin),
+        torch.empty(num_copy_ops, dtype=torch.int64, pin_memory=pin),
+        torch.empty(num_copy_ops, dtype=torch.int64, pin_memory=pin),
+    )
+
+
 class SingleDirectionOffloadingHandler(OffloadingHandler):
     """
     SingleDirectionOffloadingHandler handles transfers for a single direction,
@@ -162,6 +206,9 @@ class SingleDirectionOffloadingHandler(OffloadingHandler):
         )
         self.gpu_to_cpu: bool = gpu_to_cpu
         self.kv_cache_groups_data_refs = kv_cache_groups_data_refs
+        self._swap_blocks_batch = _select_swap_blocks_fn(
+            kv_cache_groups_data_refs, gpu_to_cpu
+        )
 
         # GPU blocks may be smaller
         # cpu_page_size = gpu_page_size * block_size_factor.
@@ -179,6 +226,8 @@ class SingleDirectionOffloadingHandler(OffloadingHandler):
         self._stream_pool: list[torch.cuda.Stream] = []
         # list of CUDA events available for re-use
         self._event_pool: list[torch.Event] = []
+        # list of pinned descriptor buffer sets available for re-use
+        self._buffer_pool: list[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = []
 
     @override
     def transfer_async(self, job_id: int, transfer_spec: TransferSpec) -> bool:
@@ -229,9 +278,21 @@ class SingleDirectionOffloadingHandler(OffloadingHandler):
         ):
             num_copy_ops += group_size * len(group_data_refs)
 
-        all_src = np.empty(num_copy_ops, dtype=np.int64)
-        all_dst = np.empty(num_copy_ops, dtype=np.int64)
-        all_sizes = np.empty(num_copy_ops, dtype=np.int64)
+        # reuse a pooled buffer set, growing it if this transfer needs more room
+        batch_src, batch_dst, batch_sizes = (
+            self._buffer_pool.pop()
+            if self._buffer_pool
+            else _new_descriptor_buffers(num_copy_ops)
+        )
+        if batch_src.numel() < num_copy_ops:
+            batch_src, batch_dst, batch_sizes = _new_descriptor_buffers(num_copy_ops)
+
+        src = batch_src[:num_copy_ops]
+        dst = batch_dst[:num_copy_ops]
+        sizes = batch_sizes[:num_copy_ops]
+        all_src = src.numpy()
+        all_dst = dst.numpy()
+        all_sizes = sizes.numpy()
 
         src_offset = 0
         dst_offset = 0
@@ -294,10 +355,6 @@ class SingleDirectionOffloadingHandler(OffloadingHandler):
         assert dst_offset == num_dst_blocks
         assert op_idx == num_copy_ops
 
-        batch_src = torch.from_numpy(all_src)
-        batch_dst = torch.from_numpy(all_dst)
-        batch_sizes = torch.from_numpy(all_sizes)
-
         stream = self._stream_pool.pop() if self._stream_pool else torch.cuda.Stream()
         start_event = (
             self._event_pool.pop()
@@ -328,10 +385,10 @@ class SingleDirectionOffloadingHandler(OffloadingHandler):
         with torch.cuda.stream(stream):
             start_event.record(stream)
             if num_copy_ops > 0:
-                ops.swap_blocks_batch(
-                    batch_src,
-                    batch_dst,
-                    batch_sizes,
+                self._swap_blocks_batch(
+                    src,
+                    dst,
+                    sizes,
                     is_src_access_order_any=is_src_access_order_any,
                 )
             end_event.record(stream)
@@ -344,6 +401,9 @@ class SingleDirectionOffloadingHandler(OffloadingHandler):
                 start_event=start_event,
                 end_event=end_event,
                 num_bytes=num_transfer_bytes,
+                batch_src=batch_src,
+                batch_dst=batch_dst,
+                batch_sizes=batch_sizes,
             )
         )
 
@@ -370,6 +430,9 @@ class SingleDirectionOffloadingHandler(OffloadingHandler):
             self._stream_pool.append(transfer.stream)
             self._event_pool.append(transfer.end_event)
             self._event_pool.append(transfer.start_event)
+            self._buffer_pool.append(
+                (transfer.batch_src, transfer.batch_dst, transfer.batch_sizes)
+            )
             del self._transfer_events[transfer.job_id]
         return results
 
@@ -388,6 +451,7 @@ class SingleDirectionOffloadingHandler(OffloadingHandler):
         self._transfer_events.clear()
         self._stream_pool.clear()
         self._event_pool.clear()
+        self._buffer_pool.clear()
         self.src_tensors.clear()
         self.dst_tensors.clear()
         if self._mmap_region is not None:

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -35,24 +35,26 @@ class SharedOffloadRegion:
     File path: /dev/shm/vllm_offload_{instance_id}.mmap
     """
 
+    BLOCK_SIZE_ALIGNMENT: int = mmap.PAGESIZE
+
     def __init__(
         self,
         instance_id: str,
-        total_size_bytes: int,
         num_blocks: int,
         rank: int | None,
-        num_workers: int,
+        kv_bytes_per_block: int,
         cpu_page_size: int,
     ) -> None:
         self.page_size = mmap.PAGESIZE
+        assert kv_bytes_per_block % self.page_size == 0
 
-        self.total_size_bytes = total_size_bytes
+        self.num_blocks = num_blocks
+        self._row_stride = kv_bytes_per_block
+        self.total_size_bytes = self.num_blocks * self._row_stride
+
         self.mmap_path = f"/dev/shm/vllm_offload_{instance_id}.mmap"
         self._creator = False  # set True only if this worker creates the file
-        self.num_blocks = num_blocks
         self.rank = rank
-        # interleaved-layout stride: one row = all workers' data for one block
-        self._row_stride = cpu_page_size * num_workers
         if rank is not None:
             # byte offset to this worker's first slot within each block row
             self._worker_offset = rank * cpu_page_size

--- a/vllm/v1/kv_offload/cpu/spec.py
+++ b/vllm/v1/kv_offload/cpu/spec.py
@@ -6,6 +6,7 @@ from typing_extensions import override
 
 from vllm.config import VllmConfig
 from vllm.platforms import current_platform
+from vllm.utils.math_utils import round_up
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.kv_offload.base import (
     CanonicalKVCaches,
@@ -21,6 +22,8 @@ from vllm.v1.kv_offload.worker.worker import OffloadingHandler
 
 
 class CPUOffloadingSpec(OffloadingSpec):
+    BLOCK_SIZE_ALIGNMENT = 1
+
     def __init__(self, vllm_config: VllmConfig, kv_cache_config: KVCacheConfig):
         super().__init__(vllm_config, kv_cache_config)
 
@@ -30,26 +33,34 @@ class CPUOffloadingSpec(OffloadingSpec):
                 "cpu_bytes_to_use must be specified in kv_connector_extra_config"
             )
 
-        # calculate kv_bytes_per_offloaded_block
+        world_size = vllm_config.parallel_config.world_size
+        self.num_blocks = 0
+        self.kv_bytes_per_offloaded_block = 0
+        self.cpu_page_size_per_worker = 0
         assert kv_cache_config is not None
-        if kv_cache_config.num_blocks > 0:
+        if kv_cache_config.num_blocks > 0 and world_size > 0:
             total_gpu_kv_bytes = sum(t.size for t in kv_cache_config.kv_cache_tensors)
             kv_bytes_per_block = (
                 total_gpu_kv_bytes // kv_cache_config.num_blocks
-            ) * vllm_config.parallel_config.world_size
-        else:
-            kv_bytes_per_block = 0
+            ) * world_size
+            kv_bytes_per_offloaded_block = kv_bytes_per_block * self.block_size_factor
 
-        kv_bytes_per_offloaded_block = kv_bytes_per_block * self.block_size_factor
-        self.num_blocks = (
-            int(cpu_bytes_to_use) // kv_bytes_per_offloaded_block
-            if kv_bytes_per_offloaded_block > 0
-            else 0
-        )
-        world_size = vllm_config.parallel_config.world_size
-        self.cpu_page_size_per_worker: int = (
-            kv_bytes_per_offloaded_block // world_size if world_size > 0 else 0
-        )
+            # calculate cpu_page_size_per_worker
+            self.cpu_page_size_per_worker = kv_bytes_per_offloaded_block // world_size
+
+            # calculate num_blocks
+            aligned_kv_bytes_per_offloaded_block = round_up(
+                kv_bytes_per_offloaded_block, self.BLOCK_SIZE_ALIGNMENT
+            )
+            self.num_blocks = (
+                int(cpu_bytes_to_use) // aligned_kv_bytes_per_offloaded_block
+            )
+
+            # Expose aligned_kv_bytes_per_offloaded_block as
+            # kv_bytes_per_offloaded_block. Note that this might contain
+            # some padding. i.e. each offloaded block is of the form,
+            # |--- W0-B0---|---- W1-B0---| ... |---- Wn-B0---| *** maybe-pad *** |
+            self.kv_bytes_per_offloaded_block = aligned_kv_bytes_per_offloaded_block
 
         # scheduler-side
         self._manager: OffloadingManager | None = None

--- a/vllm/v1/kv_offload/cpu/swap_blocks_triton.py
+++ b/vllm/v1/kv_offload/cpu/swap_blocks_triton.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Triton kernel + tuned constants for the ``swap_blocks_batch`` fast path."""
+
+from __future__ import annotations
+
+import torch
+
+from vllm import _custom_ops as ops
+from vllm.triton_utils import tl, triton
+
+# Constants tuned empirically on H100 (PCIe Gen5):
+#   NUM_SMS         - smallest SM slice within 5% of peak bandwidth at the
+#                     8-32 KB block sizes that matter in practice
+#   THRESHOLD_BYTES - max payload per descriptor where Triton beats DMA; above
+#                     this the C++ cuMemcpyBatchAsync path takes the lead
+#   MIN_N           - minimum batch size where Triton's per-launch cost is
+#                     amortized; below this DMA wins
+NUM_SMS = 12
+THRESHOLD_BYTES = 28 * 1024
+MIN_N = 16
+
+
+@triton.jit
+def _swap_blocks_kernel(
+    src_addrs,
+    dst_addrs,
+    sizes,
+    n_jobs,  # type: ignore[name-defined]
+    BYTES_PER_CHUNK: tl.constexpr,  # type: ignore[name-defined]
+):
+    pid = tl.program_id(0)
+    num_progs = tl.num_programs(0)
+    WORDS_PER_CHUNK: tl.constexpr = BYTES_PER_CHUNK // 8
+    offsets = tl.arange(0, WORDS_PER_CHUNK)
+    job = pid
+    while job < n_jobs:
+        src = tl.load(src_addrs + job).to(tl.pointer_type(tl.int64))
+        dst = tl.load(dst_addrs + job).to(tl.pointer_type(tl.int64))
+        words = tl.load(sizes + job) // 8
+        for start in range(0, words, WORDS_PER_CHUNK):
+            idx = start + offsets
+            mask = idx < words
+            data = tl.load(src + idx, mask=mask, other=0)
+            tl.store(dst + idx, data, mask=mask)
+        job += num_progs
+
+
+def swap_blocks_batch(
+    src_addrs: torch.Tensor,
+    dst_addrs: torch.Tensor,
+    sizes: torch.Tensor,
+    is_src_access_order_any: bool = False,
+    *,
+    bytes_per_chunk: int,
+) -> None:
+    """Triton implementation of ``swap_blocks_batch`` for small CPU->GPU batches."""
+    n = src_addrs.numel()
+    # Too few descriptors to amortize Triton's launch cost.
+    if n < MIN_N:
+        ops.swap_blocks_batch(
+            src_addrs,
+            dst_addrs,
+            sizes,
+            is_src_access_order_any=is_src_access_order_any,
+        )
+        return
+    _swap_blocks_kernel[(min(NUM_SMS, n),)](
+        src_addrs.to("cuda", non_blocking=True),
+        dst_addrs.to("cuda", non_blocking=True),
+        sizes.to("cuda", non_blocking=True),
+        n,
+        BYTES_PER_CHUNK=bytes_per_chunk,
+    )

--- a/vllm/v1/kv_offload/tiering/spec.py
+++ b/vllm/v1/kv_offload/tiering/spec.py
@@ -63,6 +63,8 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
     memory and must transfer data through the primary tier.
     """
 
+    BLOCK_SIZE_ALIGNMENT = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
+
     def __init__(self, vllm_config: VllmConfig, kv_cache_config: KVCacheConfig):
         super().__init__(vllm_config, kv_cache_config)
         # Redeclare for mypy: parent sets this but `--follow-imports skip` hides it
@@ -96,15 +98,11 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
 
             # Create scheduler-side SharedOffloadRegion (rank=None) so the
             # primary tier can eagerly create a memoryview over _base.
-            world_size = self.vllm_config.parallel_config.world_size
             scheduler_mmap = SharedOffloadRegion(
                 instance_id=self.vllm_config.instance_id,
-                total_size_bytes=self.cpu_page_size_per_worker
-                * world_size
-                * self.num_blocks,
                 num_blocks=self.num_blocks,
                 rank=None,
-                num_workers=world_size,
+                kv_bytes_per_block=self.kv_bytes_per_offloaded_block,
                 cpu_page_size=self.cpu_page_size_per_worker,
             )
             self._scheduler_mmap = scheduler_mmap
@@ -165,16 +163,12 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
 
     @override
     def create_handlers(self, kv_caches: CanonicalKVCaches) -> CpuGpuOffloadingHandlers:
-        world_size = self.vllm_config.parallel_config.world_size
         rank = torch.accelerator.current_device_index()
         worker_mmap = SharedOffloadRegion(
             instance_id=self.vllm_config.instance_id,
-            total_size_bytes=self.cpu_page_size_per_worker
-            * world_size
-            * self.num_blocks,
             num_blocks=self.num_blocks,
             rank=rank,
-            num_workers=world_size,
+            kv_bytes_per_block=self.kv_bytes_per_offloaded_block,
             cpu_page_size=self.cpu_page_size_per_worker,
         )
         return CpuGpuOffloadingHandlers(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -104,7 +104,7 @@ from vllm.multimodal.inputs import (
     MultiModalKwargsItem,
     PlaceholderRange,
 )
-from vllm.multimodal.utils import group_and_batch_mm_kwargs
+from vllm.multimodal.utils import get_mm_features_in_window, group_and_batch_mm_kwargs
 from vllm.platforms import current_platform
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingType
@@ -3100,22 +3100,17 @@ class GPUModelRunner(
             req_state = self.requests[req_id]
             num_computed_tokens = req_state.num_computed_tokens + shift_computed_tokens
 
-            for mm_feature in req_state.mm_features:
+            mm_features = req_state.mm_features
+            lo, hi = get_mm_features_in_window(
+                mm_features,
+                start=num_computed_tokens,
+                end=num_computed_tokens + num_scheduled_tokens,
+            )
+            for i in range(lo, hi):
+                mm_feature = mm_features[i]
                 pos_info = mm_feature.mm_position
                 start_pos = pos_info.offset
                 num_encoder_tokens = pos_info.length
-
-                # The encoder output is needed if the two ranges overlap:
-                # [num_computed_tokens,
-                #  num_computed_tokens + num_scheduled_tokens) and
-                # [start_pos, start_pos + num_encoder_tokens)
-                if start_pos >= num_computed_tokens + num_scheduled_tokens:
-                    # The encoder output is not needed in this step.
-                    break
-                if start_pos + num_encoder_tokens <= num_computed_tokens:
-                    # The encoder output is already processed and stored
-                    # in the decoder's KV cache.
-                    continue
 
                 start_idx = max(num_computed_tokens - start_pos, 0)
                 end_idx = min(


### PR DESCRIPTION
## Summary

- Extracts reusable `_bucket_layers_by_page_size()` utility from `_get_kv_cache_config_deepseek_v4()` in `vllm/v1/core/kv_cache_utils.py`
- Simplifies `_pool_bytes_per_block()` DSV4 branch by deriving `page_sizes` and `num_layer_tuples` from the buckets dict
- Behavior-preserving: same allocation pattern, same `shared_by` lists, same test results

## Context

Preliminary refactoring for upstream PR vllm-project/vllm#42374 (Standardized KV cache layout). Splitting the large PR into smaller, independently-landable pieces to reduce the final diff.

## Test plan

- [x] `pytest tests/v1/core/test_kv_cache_utils.py -v` — all 57 tests pass
- [x] `pytest tests/v1/core/test_prefix_caching.py -v` — all 64 tests pass
- [x] `ruff check` and `ruff format` pass
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)